### PR TITLE
feat: use temp file for prompts in ClaudeCodeTool (#18)

### DIFF
--- a/tests/ai_tools/test_claude_code.py
+++ b/tests/ai_tools/test_claude_code.py
@@ -260,14 +260,14 @@ class TestClaudeCodeTool:
 
         # Track created temp files
         created_temp_files = []
-        original_mkstemp = mocker.MagicMock(wraps=tempfile.mkstemp)
+        original_namedtempfile = tempfile.NamedTemporaryFile
 
-        def track_mkstemp(*args, **kwargs):
-            result = original_mkstemp(*args, **kwargs)
-            created_temp_files.append(result[1])
-            return result
+        def track_namedtempfile(*args, **kwargs):
+            temp = original_namedtempfile(*args, **kwargs)
+            created_temp_files.append(temp.name)
+            return temp
 
-        mocker.patch("tempfile.mkstemp", side_effect=track_mkstemp)
+        mocker.patch("tempfile.NamedTemporaryFile", side_effect=track_namedtempfile)
 
         # Mock subprocess
         mock_process = mocker.AsyncMock()


### PR DESCRIPTION
Update ClaudeCodeTool to write prompts to a temporary file instead of passing them directly as command-line arguments. This approach:
- Avoids command-line length limits
- Eliminates special character escaping issues
- Maintains consistency with AiderTool implementation

Changes:
- Add imports: os, tempfile, aiofiles
- Update _invoke_claude to create temp file with prompt content
- Pass file reference in Claude prompt instead of full content
- Clean up temp file in finally block
- Add test for temp file cleanup verification
- Update command construction test to verify temp file usage

fixes #18 

🤖 Generated with [Claude Code](https://claude.com/claude-code)