### PR TITLE
fix: use case-sensitive project keys in SonarQube component identifiers

### DIFF
--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -610,17 +610,8 @@ def debug_issues(
                     issues = await client.get_issues_for_file(file_path)
                 else:
                     console.print("[yellow]Fetching ALL project issues (no file filter)[/yellow]\n")
-                    # Fetch without file filter
-                    params = {
-                        "componentKeys": config.sonarqube_project_key,
-                        "ps": limit,
-                        "issueStatuses": "OPEN,CONFIRMED",
-                    }
-                    data = await client._request("GET", "/api/issues/search", params=params)
-                    from vibe_heal.sonarqube.models import IssuesResponse
-
-                    response = IssuesResponse(**data)
-                    issues = response.issues
+                    # Fetch all project issues without file filter
+                    issues = await client.get_issues(component=None, page_size=limit)
 
                 console.print(f"[bold]Found {len(issues)} issues[/bold]\n")
 

--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -582,5 +582,71 @@ def version() -> None:
     console.print(f"vibe-heal version {__version__}")
 
 
+@app.command()
+def debug_issues(
+    file_path: str | None = typer.Argument(None, help="Optional file path to check"),
+    env_file: str | None = typer.Option(
+        None,
+        "--env-file",
+        help=ENV_FILE_HELP,
+    ),
+    limit: int = typer.Option(
+        10,
+        "--limit",
+        "-n",
+        help="Maximum number of issues to show",
+    ),
+) -> None:
+    """Debug: show raw issues from SonarQube (with or without file filter)."""
+    setup_logging(True)  # Always verbose for debug command
+
+    try:
+        config = VibeHealConfig(env_file=env_file)
+
+        async def _debug() -> None:
+            async with SonarQubeClient(config) as client:
+                if file_path:
+                    console.print(f"[yellow]Fetching issues for file: {file_path}[/yellow]\n")
+                    issues = await client.get_issues_for_file(file_path)
+                else:
+                    console.print("[yellow]Fetching ALL project issues (no file filter)[/yellow]\n")
+                    # Fetch without file filter
+                    params = {
+                        "componentKeys": config.sonarqube_project_key,
+                        "ps": limit,
+                        "issueStatuses": "OPEN,CONFIRMED",
+                    }
+                    data = await client._request("GET", "/api/issues/search", params=params)
+                    from vibe_heal.sonarqube.models import IssuesResponse
+
+                    response = IssuesResponse(**data)
+                    issues = response.issues
+
+                console.print(f"[bold]Found {len(issues)} issues[/bold]\n")
+
+                for idx, issue in enumerate(issues[:limit], 1):
+                    console.print(f"[cyan]Issue {idx}:[/cyan]")
+                    console.print(f"  Key: {issue.key}")
+                    console.print(f"  Rule: {issue.rule}")
+                    console.print(f"  Component: {issue.component}")
+                    console.print(f"  Line: {issue.line}")
+                    console.print(f"  Status: {issue.status!r}")
+                    console.print(f"  Issue Status: {issue.issue_status!r}")
+                    console.print(f"  Severity: {issue.severity}")
+                    console.print(f"  Message: {issue.message}")
+                    console.print(f"  Is Fixable: {issue.is_fixable}")
+                    console.print()
+
+        asyncio.run(_debug())
+
+    except ConfigurationError as e:
+        console.print(f"[red]Configuration error: {e}[/red]")
+        sys.exit(1)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        console.print_exception()
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     app()

--- a/src/vibe_heal/processor/issue_processor.py
+++ b/src/vibe_heal/processor/issue_processor.py
@@ -68,12 +68,12 @@ class IssueProcessor:
                 if issue.line is None:
                     logger.debug(
                         f"Issue {issue.key} not fixable: no line number (rule={issue.rule}, "
-                        f"message={issue.message[:50]}{'...' if len(issue.message) > 50 else ''})"
+                        f"message={issue.message[:50]}{'...' if issue.message and len(issue.message) > 50 else ''})"
                     )
                 else:
                     logger.debug(
                         f"Issue {issue.key} not fixable: status={issue.status!r} "
-                        f"(rule={issue.rule}, line={issue.line}, message={issue.message[:50]}{'...' if len(issue.message) > 50 else ''})"
+                        f"(rule={issue.rule}, line={issue.line}, message={issue.message[:50]}{'...' if issue.message and len(issue.message) > 50 else ''})"
                     )
 
         logger.debug(f"Step 1: {len(fixable)}/{total} issues are fixable")

--- a/src/vibe_heal/processor/issue_processor.py
+++ b/src/vibe_heal/processor/issue_processor.py
@@ -1,7 +1,11 @@
 """Issue processor for sorting and filtering SonarQube issues."""
 
+import logging
+
 from vibe_heal.processor.models import ProcessingResult
 from vibe_heal.sonarqube.models import SonarQubeIssue
+
+logger = logging.getLogger(__name__)
 
 
 class IssueProcessor:
@@ -52,13 +56,37 @@ class IssueProcessor:
         """
         total = len(issues)
 
+        logger.debug(f"Processing {total} issues")
+
         # Step 1: Filter fixable issues
-        fixable = [issue for issue in issues if issue.is_fixable]
+        fixable = []
+        for issue in issues:
+            if issue.is_fixable:
+                fixable.append(issue)
+            else:
+                # Log why each issue is not fixable
+                if issue.line is None:
+                    logger.debug(
+                        f"Issue {issue.key} not fixable: no line number (rule={issue.rule}, "
+                        f"message={issue.message[:50]}...)"
+                    )
+                else:
+                    logger.debug(
+                        f"Issue {issue.key} not fixable: status={issue.status!r} "
+                        f"(rule={issue.rule}, line={issue.line}, message={issue.message[:50]}...)"
+                    )
+
+        logger.debug(f"Step 1: {len(fixable)}/{total} issues are fixable")
 
         # Step 2: Filter by severity if specified
         if self.min_severity:
             min_rank = self._severity_rank.get(self.min_severity.upper(), 0)
+            before_count = len(fixable)
             fixable = [issue for issue in fixable if self._severity_rank.get(issue.severity or "INFO", 0) >= min_rank]
+            logger.debug(
+                f"Step 2: {len(fixable)}/{before_count} issues meet severity threshold "
+                f"(min_severity={self.min_severity})"
+            )
 
         # Step 3: Sort issues in reverse line order (high to low)
         # This ensures fixes don't affect line numbers of subsequent issues
@@ -66,7 +94,11 @@ class IssueProcessor:
 
         # Step 4: Limit number of issues if specified
         if self.max_issues and self.max_issues > 0:
+            before_count = len(sorted_issues)
             sorted_issues = sorted_issues[: self.max_issues]
+            logger.debug(
+                f"Step 4: limited to {len(sorted_issues)}/{before_count} issues (max_issues={self.max_issues})"
+            )
 
         return ProcessingResult(
             total_issues=total,

--- a/src/vibe_heal/processor/issue_processor.py
+++ b/src/vibe_heal/processor/issue_processor.py
@@ -68,12 +68,12 @@ class IssueProcessor:
                 if issue.line is None:
                     logger.debug(
                         f"Issue {issue.key} not fixable: no line number (rule={issue.rule}, "
-                        f"message={issue.message[:50]}...)"
+                        f"message={issue.message[:50]}{'...' if len(issue.message) > 50 else ''})"
                     )
                 else:
                     logger.debug(
                         f"Issue {issue.key} not fixable: status={issue.status!r} "
-                        f"(rule={issue.rule}, line={issue.line}, message={issue.message[:50]}...)"
+                        f"(rule={issue.rule}, line={issue.line}, message={issue.message[:50]}{'...' if len(issue.message) > 50 else ''})"
                     )
 
         logger.debug(f"Step 1: {len(fixable)}/{total} issues are fixable")

--- a/src/vibe_heal/sonarqube/client.py
+++ b/src/vibe_heal/sonarqube/client.py
@@ -153,7 +153,7 @@ class SonarQubeClient:
             logger.debug(
                 f"Issue {idx}: key={issue.key}, rule={issue.rule}, line={issue.line}, "
                 f"status={issue.status!r}, issue_status={issue.issue_status!r}, "
-                f"severity={issue.severity!r}, message={issue.message[:50]}..."
+                f"severity={issue.severity!r}, message={issue.message[:50]}{'...' if len(issue.message) > 50 else ''}"
             )
 
     def _build_issues_params(self, component: str, page: int, page_size: int, resolved: bool) -> dict[str, Any]:


### PR DESCRIPTION
Fix bug where project keys were incorrectly lowercased when constructing
SonarQube component identifiers, causing API queries to return zero issues
for projects with uppercase keys (e.g., "NERF" was queried as "nerf").

SonarQube component identifiers are case-sensitive and must match the
exact project key format. The previous implementation incorrectly assumed
lowercase normalization was required.

Changes:
- Remove .lower() call on project key in get_issues_for_file()
- Update test expectations to verify case-sensitive behavior
- Add new test case for uppercase project keys
- Add debug logging to help diagnose similar issues in the future
- Add debug-issues CLI command for troubleshooting

The bug was introduced in commit https://github.com/alexeieleusis/vibe-heal/commit/c99d614066e5ce899d8e6c9e2698857f4b19dc36 when switching from client-side
filtering to server-side component-based queries.