### PR TITLE
fix: remove completed progress tasks to prevent duplicate output lines

### DIFF
--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -464,6 +464,9 @@ class DeduplicationOrchestrator:
                     task,
                 )
 
+                # Remove the completed task to prevent duplicates in the display
+                progress.remove_task(task)
+
         return summary
 
     def _display_summary(self, summary: FixSummary, dry_run: bool) -> None:

--- a/src/vibe_heal/orchestrator.py
+++ b/src/vibe_heal/orchestrator.py
@@ -331,6 +331,9 @@ class VibeHealOrchestrator:
 
                 self._handle_fix_result(fix_result, issue, dry_run, summary, progress, task, rule)
 
+                # Remove the completed task to prevent duplicates in the display
+                progress.remove_task(task)
+
         return summary
 
     def _display_summary(self, summary: FixSummary, dry_run: bool) -> None:


### PR DESCRIPTION
Progress tasks were not being removed after completion, causing the terminal to display duplicate "Fixed line X" messages with spinning indicators. Each completed task remained visible while new tasks were added, creating visual clutter and confusion.

This fix calls progress.remove_task() immediately after handling each fix result in both the main orchestrator and deduplication orchestrator, ensuring only the current in-progress task is displayed.

Affected workflows:
- vibe-heal fix command (orchestrator.py)
- vibe-heal dedupe command (deduplication/orchestrator.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)