### PR TITLE
feat(visibility): Adds a URL pointing to the project's Github repo

### DIFF
--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -23,7 +23,7 @@ from vibe_heal.sonarqube.client import SonarQubeClient
 
 app = typer.Typer(
     name="vibe-heal",
-    help="AI-powered SonarQube issue remediation tool",
+    help="AI-powered SonarQube issue remediation tool\n\nGitHub: https://github.com/alexeieleusis/vibe-heal",
     add_completion=False,
 )
 console = Console()
@@ -289,6 +289,7 @@ def _display_cleanup_results(result: CleanupResult) -> None:
         sys.exit(1)
 
     console.print("\n[green]✨ Branch cleanup complete![/green]")
+    console.print("\n[dim]GitHub: https://github.com/alexeieleusis/vibe-heal[/dim]")
 
 
 async def _run_cleanup(
@@ -431,6 +432,7 @@ def _display_dedupe_branch_results(result: DedupeBranchResult) -> None:
         sys.exit(1)
 
     console.print("\n[green]✨ Branch deduplication complete![/green]")
+    console.print("\n[dim]GitHub: https://github.com/alexeieleusis/vibe-heal[/dim]")
 
 
 async def _run_dedupe_branch(

--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -271,7 +271,8 @@ class DeduplicationOrchestrator:
             f"({target_block.size} lines).\n\n"
             f"This code was duplicated in {len(group.blocks)} location(s):\n"
             f"{locations_text}\n\n"
-            f"AI tool: {self.ai_tool.tool_type.display_name}"
+            f"AI tool: {self.ai_tool.tool_type.display_name}\n\n"
+            f"[vibe-heal](https://github.com/alexeieleusis/vibe-heal)"
         )
 
     def _handle_successful_fix_commit(
@@ -490,6 +491,8 @@ class DeduplicationOrchestrator:
 
         if dry_run:
             self.console.print("\n[yellow]Dry-run mode: no changes committed[/yellow]")
+
+        self.console.print("\n[dim]GitHub: https://github.com/alexeieleusis/vibe-heal[/dim]")
 
 
 class FileDedupResult(BaseModel):

--- a/src/vibe_heal/git/manager.py
+++ b/src/vibe_heal/git/manager.py
@@ -320,7 +320,11 @@ class GitManager:
                 "",
             ])
 
-        body_parts.append(f"Fixed by: vibe-heal using {ai_tool_type.display_name}")
+        body_parts.extend([
+            f"Fixed by: vibe-heal using {ai_tool_type.display_name}",
+            "",
+            "[vibe-heal](https://github.com/alexeieleusis/vibe-heal)",
+        ])
 
         body = "\n".join(body_parts)
 

--- a/src/vibe_heal/orchestrator.py
+++ b/src/vibe_heal/orchestrator.py
@@ -357,3 +357,5 @@ class VibeHealOrchestrator:
 
         if dry_run:
             self.console.print("\n[yellow]Dry-run mode: no changes committed[/yellow]")
+
+        self.console.print("\n[dim]GitHub: https://github.com/alexeieleusis/vibe-heal[/dim]")


### PR DESCRIPTION
1. CLI Help Page (cli.py:24-28)

Added the GitHub URL to the main Typer app help text: help="AI-powered SonarQube issue remediation tool\n\nGitHub: https://github.com/alexeieleusis/vibe-heal"

2. Summary Outputs

Added the GitHub URL at the end of each command's summary output:

- fix command (orchestrator.py:361): Added after the summary display
- dedupe command (deduplication/orchestrator.py:494): Added after the summary display
- cleanup command (cli.py:292): Added after "Branch cleanup complete!" message
- dedupe-branch command (cli.py:435): Added after "Branch deduplication complete!" message

All summary outputs now display: GitHub: https://github.com/alexeieleusis/vibe-heal in a dimmed style.

3. Commit Messages

Added the GitHub URL in Markdown format to commit messages so they're clickable on GitHub:

- fix command commits (git/manager.py:326): Added [vibe-heal](https://github.com/alexeieleusis/vibe-heal) at the end
- dedupe command commits (deduplication/orchestrator.py:275): Added [vibe-heal](https://github.com/alexeieleusis/vibe-heal) at the end

The Markdown format [vibe-heal](URL) will render as a clickable link when viewed on GitHub!

All changes are complete and ready to use.