### PR TITLE
feat(ai_tools): add OpenCode tool support (#62)

### DIFF
--- a/src/vibe_heal/ai_tools/__init__.py
+++ b/src/vibe_heal/ai_tools/__init__.py
@@ -6,6 +6,7 @@ from vibe_heal.ai_tools.claude_code import ClaudeCodeTool
 from vibe_heal.ai_tools.factory import AIToolFactory
 from vibe_heal.ai_tools.gemini import GeminiCliTool
 from vibe_heal.ai_tools.models import FixResult
+from vibe_heal.ai_tools.opencode import OpenCodeTool
 from vibe_heal.ai_tools.prompts import create_fix_prompt
 
 __all__ = [
@@ -16,5 +17,6 @@ __all__ = [
     "ClaudeCodeTool",
     "FixResult",
     "GeminiCliTool",
+    "OpenCodeTool",
     "create_fix_prompt",
 ]

--- a/src/vibe_heal/ai_tools/base.py
+++ b/src/vibe_heal/ai_tools/base.py
@@ -15,6 +15,7 @@ class AIToolType(str, Enum):
     AIDER = "aider"
     CLAUDE_CODE = "claude-code"
     GEMINI = "gemini"
+    OPENCODE = "opencode"
 
     @property
     def cli_command(self) -> str:
@@ -36,6 +37,7 @@ class AIToolType(str, Enum):
             AIToolType.CLAUDE_CODE: "Claude Code",
             AIToolType.AIDER: "Aider",
             AIToolType.GEMINI: "Gemini",
+            AIToolType.OPENCODE: "OpenCode",
         }[self]
 
 

--- a/src/vibe_heal/ai_tools/factory.py
+++ b/src/vibe_heal/ai_tools/factory.py
@@ -66,6 +66,7 @@ class AIToolFactory:
         1. Claude Code
         2. Aider
         3. Gemini
+        4. OpenCode
 
         Returns:
             AIToolType of first available tool, or None if none found

--- a/src/vibe_heal/ai_tools/factory.py
+++ b/src/vibe_heal/ai_tools/factory.py
@@ -6,6 +6,7 @@ from vibe_heal.ai_tools.aider import AiderTool
 from vibe_heal.ai_tools.base import AITool, AIToolType
 from vibe_heal.ai_tools.claude_code import ClaudeCodeTool
 from vibe_heal.ai_tools.gemini import GeminiCliTool
+from vibe_heal.ai_tools.opencode import OpenCodeTool
 
 if TYPE_CHECKING:
     from vibe_heal.config import VibeHealConfig
@@ -18,6 +19,7 @@ class AIToolFactory:
         AIToolType.CLAUDE_CODE: ClaudeCodeTool,
         AIToolType.AIDER: AiderTool,
         AIToolType.GEMINI: GeminiCliTool,
+        AIToolType.OPENCODE: OpenCodeTool,
     }
 
     @staticmethod
@@ -51,6 +53,9 @@ class AIToolFactory:
         if tool_type == AIToolType.GEMINI:
             return GeminiCliTool()
 
+        if tool_type == AIToolType.OPENCODE:
+            return OpenCodeTool()
+
         raise ValueError(f"Unsupported AI tool type: {tool_type}")
 
     @staticmethod
@@ -66,7 +71,7 @@ class AIToolFactory:
             AIToolType of first available tool, or None if none found
         """
         # Try in preference order
-        for tool_type in [AIToolType.CLAUDE_CODE, AIToolType.AIDER, AIToolType.GEMINI]:
+        for tool_type in [AIToolType.CLAUDE_CODE, AIToolType.AIDER, AIToolType.GEMINI, AIToolType.OPENCODE]:
             try:
                 tool = AIToolFactory.create(tool_type)
                 if tool.is_available():

--- a/src/vibe_heal/ai_tools/opencode.py
+++ b/src/vibe_heal/ai_tools/opencode.py
@@ -1,0 +1,162 @@
+"""OpenCode AI tool implementation."""
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from vibe_heal.ai_tools.base import AITool, AIToolType
+from vibe_heal.ai_tools.models import FixResult
+from vibe_heal.ai_tools.utils import run_command
+
+if TYPE_CHECKING:
+    from vibe_heal.sonarqube.models import SonarQubeIssue, SonarQubeRule, SourceLine
+
+
+class OpenCodeTool(AITool):
+    """OpenCode AI tool implementation."""
+
+    tool_type = AIToolType.OPENCODE
+
+    def __init__(
+        self,
+        timeout: int = 900,
+        model: str | None = None,
+    ) -> None:
+        """Initialize OpenCode tool.
+
+        Args:
+            timeout: Timeout in seconds for AI operations (default: 15 minutes)
+            model: Model to use in provider/model format (e.g., 'anthropic/claude-sonnet-4-5')
+        """
+        self.timeout = timeout
+        self.model = model
+
+    def is_available(self) -> bool:
+        """Check if OpenCode CLI is installed.
+
+        Returns:
+            True if opencode command is available
+        """
+        return shutil.which("opencode") is not None
+
+    async def fix_issue(
+        self,
+        issue: "SonarQubeIssue",
+        file_path: str,
+        rule: "SonarQubeRule | None" = None,
+        code_context: "list[SourceLine] | None" = None,
+    ) -> FixResult:
+        """Fix an issue using OpenCode.
+
+        Args:
+            issue: The SonarQube issue to fix
+            file_path: Path to the file containing the issue
+            rule: Detailed rule information (optional)
+            code_context: Source code lines around the issue (optional)
+
+        Returns:
+            Result of the fix attempt
+        """
+        from vibe_heal.ai_tools.prompts import create_fix_prompt
+
+        if not self.is_available():
+            return FixResult(
+                success=False,
+                error_message="OpenCode CLI not found. Please install OpenCode first.",
+            )
+
+        if not Path(file_path).exists():
+            return FixResult(
+                success=False,
+                error_message=f"File not found: {file_path}",
+            )
+
+        prompt = create_fix_prompt(issue, file_path, rule=rule, code_context=code_context)
+
+        try:
+            result = await self._invoke_opencode(prompt, file_path)
+            return result
+        except asyncio.TimeoutError:
+            return FixResult(
+                success=False,
+                error_message=f"OpenCode timed out after {self.timeout} seconds",
+            )
+        except Exception as e:
+            return FixResult(
+                success=False,
+                error_message=f"Error invoking OpenCode: {e}",
+            )
+
+    async def fix_duplication(
+        self,
+        prompt: str,
+        file_path: str,
+    ) -> FixResult:
+        """Fix code duplication using OpenCode.
+
+        Args:
+            prompt: Detailed prompt describing the duplication
+            file_path: Path to the file containing the duplication
+
+        Returns:
+            Result of the fix attempt
+        """
+        if not self.is_available():
+            return FixResult(
+                success=False,
+                error_message="OpenCode CLI not found. Please install OpenCode first.",
+            )
+
+        if not Path(file_path).exists():
+            return FixResult(
+                success=False,
+                error_message=f"File not found: {file_path}",
+            )
+
+        try:
+            result = await self._invoke_opencode(prompt, file_path)
+            return result
+        except asyncio.TimeoutError:
+            return FixResult(
+                success=False,
+                error_message=f"OpenCode timed out after {self.timeout} seconds",
+            )
+        except Exception as e:
+            return FixResult(
+                success=False,
+                error_message=f"Error invoking OpenCode: {e}",
+            )
+
+    async def _invoke_opencode(
+        self,
+        prompt: str,
+        file_path: str,
+    ) -> FixResult:
+        """Invoke OpenCode CLI.
+
+        Args:
+            prompt: The prompt to send to OpenCode
+            file_path: File to fix
+
+        Returns:
+            FixResult with outcome
+        """
+        cmd = ["opencode", "run", prompt]
+
+        if self.model:
+            cmd.extend(["-m", self.model])
+
+        result = await run_command(cmd, timeout=self.timeout)
+
+        if result.success:
+            return FixResult(
+                success=True,
+                files_modified=[file_path],
+                ai_response=result.stdout,
+            )
+        return FixResult(
+            success=False,
+            error_message=f"OpenCode failed with exit code {result.exit_code}: {result.stderr}",
+            ai_response=result.stdout,
+        )

--- a/tests/ai_tools/test_opencode.py
+++ b/tests/ai_tools/test_opencode.py
@@ -1,0 +1,315 @@
+"""Tests for OpenCode AI tool."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from vibe_heal.ai_tools import OpenCodeTool
+from vibe_heal.sonarqube.models import SonarQubeIssue
+
+
+@pytest.fixture
+def sample_issue() -> SonarQubeIssue:
+    """Create a sample issue for testing."""
+    return SonarQubeIssue(
+        key="test-123",
+        rule="python:S1481",
+        severity="MAJOR",
+        message="Remove unused variable",
+        component="project:src/test.py",
+        line=10,
+        status="OPEN",
+        type="CODE_SMELL",
+    )
+
+
+class TestOpenCodeTool:
+    """Tests for OpenCodeTool."""
+
+    def test_is_available_when_opencode_exists(self, mocker: MockerFixture) -> None:
+        """Test is_available returns True when opencode is installed."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        tool = OpenCodeTool()
+        assert tool.is_available() is True
+
+    def test_is_available_when_opencode_missing(self, mocker: MockerFixture) -> None:
+        """Test is_available returns False when opencode is not installed."""
+        mocker.patch("shutil.which", return_value=None)
+
+        tool = OpenCodeTool()
+        assert tool.is_available() is False
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_when_tool_not_available(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+    ) -> None:
+        """Test fix_issue returns error when tool not available."""
+        mocker.patch("shutil.which", return_value=None)
+
+        tool = OpenCodeTool()
+        result = await tool.fix_issue(sample_issue, "src/test.py")
+
+        assert result.success is False
+        assert result.failed is True
+        assert "not found" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_when_file_not_found(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+        tmp_path: Path,
+    ) -> None:
+        """Test fix_issue returns error when file doesn't exist."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        tool = OpenCodeTool()
+        nonexistent_file = tmp_path / "nonexistent.py"
+        result = await tool.fix_issue(sample_issue, str(nonexistent_file))
+
+        assert result.success is False
+        assert "File not found" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_success(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+        tmp_path: Path,
+    ) -> None:
+        """Test successful fix execution."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def foo():\n    unused = 1\n    pass\n")
+
+        mock_process = mocker.AsyncMock()
+        mock_process.communicate.return_value = (b"Fixed the issue", b"")
+        mock_process.returncode = 0
+
+        mocker.patch("asyncio.create_subprocess_exec", return_value=mock_process)
+
+        tool = OpenCodeTool()
+        result = await tool.fix_issue(sample_issue, str(test_file))
+
+        assert result.success is True
+        assert result.failed is False
+        assert str(test_file) in result.files_modified
+        assert result.error_message is None
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_command_failure(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+        tmp_path: Path,
+    ) -> None:
+        """Test handling of command execution failure."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        mock_process = mocker.AsyncMock()
+        mock_process.communicate.return_value = (b"", b"Error: Command failed")
+        mock_process.returncode = 1
+
+        mocker.patch("asyncio.create_subprocess_exec", return_value=mock_process)
+
+        tool = OpenCodeTool()
+        result = await tool.fix_issue(sample_issue, str(test_file))
+
+        assert result.success is False
+        assert "failed" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_timeout(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+        tmp_path: Path,
+    ) -> None:
+        """Test handling of timeout."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        mock_process = mocker.AsyncMock()
+        mock_process.communicate.side_effect = asyncio.TimeoutError()
+        mock_process.kill = mocker.Mock()
+        mock_process.wait = mocker.AsyncMock()
+
+        mocker.patch("asyncio.create_subprocess_exec", return_value=mock_process)
+
+        tool = OpenCodeTool(timeout=1)
+        result = await tool.fix_issue(sample_issue, str(test_file))
+
+        assert result.success is False
+        assert "timed out" in result.error_message.lower()
+        mock_process.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_exception_handling(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+        tmp_path: Path,
+    ) -> None:
+        """Test handling of unexpected exceptions."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        mocker.patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=RuntimeError("Unexpected error"),
+        )
+
+        tool = OpenCodeTool()
+        result = await tool.fix_issue(sample_issue, str(test_file))
+
+        assert result.success is False
+        assert "Error invoking OpenCode" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_command_construction(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+        tmp_path: Path,
+    ) -> None:
+        """Test that command is constructed correctly."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        mock_process = mocker.AsyncMock()
+        mock_process.communicate.return_value = (b"Fixed", b"")
+        mock_process.returncode = 0
+
+        mock_create_subprocess = mocker.patch(
+            "asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        )
+
+        tool = OpenCodeTool()
+        await tool.fix_issue(sample_issue, str(test_file))
+
+        args, _ = mock_create_subprocess.call_args
+        assert args[0] == "opencode"
+        assert args[1] == "run"
+        assert len(args) >= 3  # opencode run <prompt>
+
+    @pytest.mark.asyncio
+    async def test_fix_issue_command_includes_model(
+        self,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+        tmp_path: Path,
+    ) -> None:
+        """Test that -m flag is added when model is specified."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        mock_process = mocker.AsyncMock()
+        mock_process.communicate.return_value = (b"Fixed", b"")
+        mock_process.returncode = 0
+
+        mock_create_subprocess = mocker.patch(
+            "asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        )
+
+        tool = OpenCodeTool(model="anthropic/claude-sonnet-4-5")
+        await tool.fix_issue(sample_issue, str(test_file))
+
+        args, _ = mock_create_subprocess.call_args
+        assert "-m" in args
+        model_index = list(args).index("-m")
+        assert args[model_index + 1] == "anthropic/claude-sonnet-4-5"
+
+    def test_custom_timeout(self) -> None:
+        """Test that custom timeout is accepted."""
+        tool = OpenCodeTool(timeout=600)
+        assert tool.timeout == 600
+
+    def test_initialization_with_model(self) -> None:
+        """Test that model config is properly stored."""
+        tool = OpenCodeTool(model="anthropic/claude-sonnet-4-5")
+        assert tool.model == "anthropic/claude-sonnet-4-5"
+
+    @pytest.mark.asyncio
+    async def test_fix_duplication_success(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Test successful duplication fix."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        mock_process = mocker.AsyncMock()
+        mock_process.communicate.return_value = (b"Refactored", b"")
+        mock_process.returncode = 0
+
+        mocker.patch("asyncio.create_subprocess_exec", return_value=mock_process)
+
+        tool = OpenCodeTool()
+        result = await tool.fix_duplication("Remove duplicate code", str(test_file))
+
+        assert result.success is True
+        assert str(test_file) in result.files_modified
+
+    @pytest.mark.asyncio
+    async def test_fix_duplication_failure(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Test failed duplication fix."""
+        mocker.patch("shutil.which", return_value="/usr/local/bin/opencode")
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        mock_process = mocker.AsyncMock()
+        mock_process.communicate.return_value = (b"", b"Error")
+        mock_process.returncode = 1
+
+        mocker.patch("asyncio.create_subprocess_exec", return_value=mock_process)
+
+        tool = OpenCodeTool()
+        result = await tool.fix_duplication("Remove duplicate code", str(test_file))
+
+        assert result.success is False
+        assert result.error_message is not None
+
+    @pytest.mark.asyncio
+    async def test_fix_duplication_tool_not_available(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Test fix_duplication returns error when tool not available."""
+        mocker.patch("shutil.which", return_value=None)
+
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        tool = OpenCodeTool()
+        result = await tool.fix_duplication("Remove duplicate code", str(test_file))
+
+        assert result.success is False
+        assert "not found" in result.error_message.lower()


### PR DESCRIPTION
Implements OpenCodeTool using `opencode run <prompt>` in non-interactive mode. Uses exit-code-based success detection (same pattern as Aider) with a 900s default timeout to accommodate slow local LLMs. Supports optional -m/--model flag and auto-detection as lowest-priority fallback.