### PR TITLE
feat: copy exclusion settings to temp projects in cleanup/dedupe-branch (#109)

### DIFF
--- a/docs/superpowers/specs/2026-05-11-copy-exclusion-settings-to-temp-project-design.md
+++ b/docs/superpowers/specs/2026-05-11-copy-exclusion-settings-to-temp-project-design.md
@@ -1,0 +1,174 @@
+# Design: Copy Exclusion Settings to Temporary SonarQube Projects
+
+**Date:** 2026-05-11
+**Status:** Approved
+**Commands affected:** `vibe-heal cleanup`, `vibe-heal dedupe-branch`
+
+## Problem
+
+When `cleanup` or `dedupe-branch` run, they create a fresh temporary SonarQube project
+(`ProjectManager.create_temp_project()`). This blank project inherits none of the exclusion
+settings from the original project — in particular `sonar.cpd.exclusions` (files to ignore
+for code duplication). As a result, the analysis reports duplication issues on files that
+the original project intentionally excludes, and the AI tool attempts to fix them
+unnecessarily.
+
+## Goal
+
+After creating the temporary project, copy the source project's exclusion settings to it so
+the temp project's analysis behavior matches the original as closely as possible.
+
+## Scope
+
+### Settings copied
+
+The following SonarQube settings keys are copied:
+
+- `sonar.exclusions` — source files excluded from analysis
+- `sonar.test.exclusions` — test files excluded from analysis
+- `sonar.coverage.exclusions` — files excluded from coverage
+- `sonar.cpd.exclusions` — files excluded from duplication detection
+- `sonar.inclusions` — source files included (restricts scope)
+- `sonar.test.inclusions` — test files included
+
+Only settings **explicitly set on the source project** (not inherited from global defaults)
+are copied. The `inherited` flag from the SonarQube API is used to distinguish these.
+
+### Out of scope
+
+Quality gates, quality profiles, permissions, and all other non-exclusion settings are not
+copied. The temp project is short-lived and these settings would add complexity without
+meaningful benefit.
+
+## Error handling
+
+Copying settings is best-effort. If the fetch or write fails for any reason (insufficient
+API permissions, unsupported SonarQube version, network error), the orchestrator logs a
+yellow warning and proceeds. The temp project will have no exclusions, which is the current
+behavior.
+
+## Architecture
+
+### Approach selected: Approach B — new `copy_exclusion_settings()` on `ProjectManager`
+
+`create_temp_project()` is left unchanged. Settings transfer is a separate, explicit step
+called by orchestrators after project creation. This keeps creation and configuration as
+distinct, independently testable concerns.
+
+## Component changes
+
+### 1. `SonarQubeClient` (`src/vibe_heal/sonarqube/client.py`)
+
+Two new async methods:
+
+```python
+async def get_project_settings(self, project_key: str) -> list[dict]:
+    """GET /api/settings/values?component=<project_key>
+    Returns the raw list of setting dicts from the API response."""
+
+async def set_project_setting(
+    self, project_key: str, setting_key: str, values: list[str]
+) -> None:
+    """POST /api/settings/set
+    Uses multi-value form since exclusion settings are always path-pattern lists."""
+```
+
+Both scalar (`value`) and multi-value (`values`) shapes returned by the API are normalised
+to `list[str]` before `set_project_setting` is called.
+
+### 2. `ProjectManager` (`src/vibe_heal/sonarqube/project_manager.py`)
+
+Class-level constant:
+
+```python
+EXCLUSION_SETTINGS = [
+    "sonar.exclusions",
+    "sonar.test.exclusions",
+    "sonar.coverage.exclusions",
+    "sonar.cpd.exclusions",
+    "sonar.inclusions",
+    "sonar.test.inclusions",
+]
+```
+
+New method:
+
+```python
+async def copy_exclusion_settings(self, source_key: str, target_key: str) -> list[str]:
+    """Copy exclusion settings from source project to target project.
+
+    Steps:
+    1. GET /api/settings/values?component=source_key
+    2. Filter to EXCLUSION_SETTINGS keys that are not inherited
+    3. POST each to the target project
+    4. Return list of setting keys that were copied
+
+    Raises SonarQubeAPIError if the fetch step fails (caller handles warn-and-continue).
+    Individual set failures are silently skipped.
+    """
+```
+
+### 3. `CleanupOrchestrator._create_temp_project()` (`src/vibe_heal/cleanup/orchestrator.py`)
+
+After the existing `create_temp_project()` call:
+
+```python
+try:
+    copied = await self.project_manager.copy_exclusion_settings(
+        source_key=self.config.sonarqube_project_key,
+        target_key=temp_project.project_key,
+    )
+    if copied:
+        console.print(f"[dim]Copied {len(copied)} exclusion setting(s): {', '.join(copied)}[/dim]")
+    else:
+        console.print("[dim]No exclusion settings to copy[/dim]")
+except Exception as e:
+    console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")
+```
+
+### 4. `DedupeBranchOrchestrator._create_temp_project()` (`src/vibe_heal/deduplication/orchestrator.py`)
+
+Identical addition as Section 3 above.
+
+## Data flow
+
+```
+cleanup / dedupe-branch
+    └─ _create_temp_project()
+           ├─ project_manager.create_temp_project()   [unchanged]
+           └─ project_manager.copy_exclusion_settings(source, target)
+                  ├─ client.get_project_settings(source)
+                  │      GET /api/settings/values?component=source
+                  ├─ filter: key in EXCLUSION_SETTINGS and not inherited
+                  └─ for each matching setting:
+                         client.set_project_setting(target, key, values)
+                                POST /api/settings/set
+```
+
+## Testing
+
+### `tests/sonarqube/test_client.py`
+
+- `test_get_project_settings` — mocks `_request`; asserts raw list returned correctly for
+  both scalar and multi-value setting shapes
+- `test_set_project_setting` — asserts POST called with correct params (multi-value form)
+
+### `tests/sonarqube/test_project_manager.py`
+
+- `test_copy_exclusion_settings_copies_non_inherited` — source has 3 settings, one
+  inherited; asserts only 2 non-inherited ones are applied to target
+- `test_copy_exclusion_settings_returns_empty_when_none_match` — source settings contain
+  none of the EXCLUSION_SETTINGS keys; asserts `[]` returned, no set calls made
+- `test_copy_exclusion_settings_raises_if_fetch_fails` — `get_project_settings` raises
+  `SonarQubeAPIError`; asserts the error propagates out of `copy_exclusion_settings`
+  (callers own the warn-and-continue, not this method)
+
+### `tests/cleanup/test_orchestrator.py`
+
+- `test_create_temp_project_warns_on_settings_copy_failure` — `copy_exclusion_settings`
+  raises; asserts orchestrator prints yellow warning and does not re-raise
+
+### `tests/deduplication/test_orchestrator.py`
+
+- `test_create_temp_project_warns_on_settings_copy_failure` — same as above for the dedupe
+  orchestrator

--- a/docs/superpowers/specs/2026-05-11-copy-exclusion-settings-to-temp-project-design.md
+++ b/docs/superpowers/specs/2026-05-11-copy-exclusion-settings-to-temp-project-design.md
@@ -81,30 +81,33 @@ to `list[str]` before `set_project_setting` is called.
 Class-level constant:
 
 ```python
-EXCLUSION_SETTINGS = [
+EXCLUSION_SETTINGS: ClassVar[tuple[str, ...]] = (
     "sonar.exclusions",
     "sonar.test.exclusions",
     "sonar.coverage.exclusions",
     "sonar.cpd.exclusions",
     "sonar.inclusions",
     "sonar.test.inclusions",
-]
+)
 ```
 
 New method:
 
 ```python
-async def copy_exclusion_settings(self, source_key: str, target_key: str) -> tuple[list[str], int]:
+async def copy_exclusion_settings(
+    self, source_key: str, target_key: str
+) -> tuple[list[str], int, int]:
     """Copy exclusion settings from source project to target project.
 
     Steps:
     1. GET /api/settings/values?component=source_key
     2. Filter to EXCLUSION_SETTINGS keys that are not inherited
     3. POST each to the target project
-    4. Return tuple of (list of keys that were copied, count of inherited keys skipped)
+    4. Return tuple of (list of keys that were copied, count of inherited keys skipped,
+       count of keys that failed to apply)
 
-    Raises SonarQubeAPIError if the fetch step fails (caller handles warn-and-continue).
-    Individual set failures are logged and skipped.
+    Raises SonarQubeError if the fetch step fails (caller handles warn-and-continue).
+    Individual set failures are logged and counted, not re-raised.
     """
 ```
 
@@ -114,7 +117,7 @@ After the existing `create_temp_project()` call:
 
 ```python
 try:
-    copied, inherited_count = await self.project_manager.copy_exclusion_settings(
+    copied, inherited_count, failed_count = await self.project_manager.copy_exclusion_settings(
         source_key=self.config.sonarqube_project_key,
         target_key=temp_project.project_key,
     )
@@ -122,15 +125,17 @@ try:
         console.print(f"[dim]Copied {len(copied)} exclusion setting(s): {', '.join(copied)}[/dim]")
     if inherited_count:
         console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
-    if not copied and not inherited_count:
+    if failed_count:
+        console.print(f"[yellow]Warning: Failed to apply {failed_count} exclusion setting(s)[/yellow]")
+    if not copied and not inherited_count and not failed_count:
         console.print("[dim]No exclusion settings configured on source project[/dim]")
-except Exception as e:
+except SonarQubeError as e:
     console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")
 ```
 
 ### 4. `DedupeBranchOrchestrator._create_temp_project()` (`src/vibe_heal/deduplication/orchestrator.py`)
 
-Identical addition as Section 3 above.
+Identical addition as Section 3 above, but using `self.console.print()` instead of the module-level `console.print()`.
 
 ## Data flow
 
@@ -173,4 +178,4 @@ cleanup / dedupe-branch
 ### `tests/deduplication/test_branch_orchestrator.py`
 
 - `test_create_temp_project_warns_on_settings_copy_failure` — same as above for the dedupe
-  orchestrator
+  branch orchestrator

--- a/docs/superpowers/specs/2026-05-11-copy-exclusion-settings-to-temp-project-design.md
+++ b/docs/superpowers/specs/2026-05-11-copy-exclusion-settings-to-temp-project-design.md
@@ -94,17 +94,17 @@ EXCLUSION_SETTINGS = [
 New method:
 
 ```python
-async def copy_exclusion_settings(self, source_key: str, target_key: str) -> list[str]:
+async def copy_exclusion_settings(self, source_key: str, target_key: str) -> tuple[list[str], int]:
     """Copy exclusion settings from source project to target project.
 
     Steps:
     1. GET /api/settings/values?component=source_key
     2. Filter to EXCLUSION_SETTINGS keys that are not inherited
     3. POST each to the target project
-    4. Return list of setting keys that were copied
+    4. Return tuple of (list of keys that were copied, count of inherited keys skipped)
 
     Raises SonarQubeAPIError if the fetch step fails (caller handles warn-and-continue).
-    Individual set failures are silently skipped.
+    Individual set failures are logged and skipped.
     """
 ```
 
@@ -114,14 +114,16 @@ After the existing `create_temp_project()` call:
 
 ```python
 try:
-    copied = await self.project_manager.copy_exclusion_settings(
+    copied, inherited_count = await self.project_manager.copy_exclusion_settings(
         source_key=self.config.sonarqube_project_key,
         target_key=temp_project.project_key,
     )
     if copied:
         console.print(f"[dim]Copied {len(copied)} exclusion setting(s): {', '.join(copied)}[/dim]")
-    else:
-        console.print("[dim]No exclusion settings to copy[/dim]")
+    if inherited_count:
+        console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
+    if not copied and not inherited_count:
+        console.print("[dim]No exclusion settings configured on source project[/dim]")
 except Exception as e:
     console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")
 ```
@@ -158,7 +160,7 @@ cleanup / dedupe-branch
 - `test_copy_exclusion_settings_copies_non_inherited` — source has 3 settings, one
   inherited; asserts only 2 non-inherited ones are applied to target
 - `test_copy_exclusion_settings_returns_empty_when_none_match` — source settings contain
-  none of the EXCLUSION_SETTINGS keys; asserts `[]` returned, no set calls made
+  none of the EXCLUSION_SETTINGS keys; asserts `([], 0)` returned, no set calls made
 - `test_copy_exclusion_settings_raises_if_fetch_fails` — `get_project_settings` raises
   `SonarQubeAPIError`; asserts the error propagates out of `copy_exclusion_settings`
   (callers own the warn-and-continue, not this method)
@@ -168,7 +170,7 @@ cleanup / dedupe-branch
 - `test_create_temp_project_warns_on_settings_copy_failure` — `copy_exclusion_settings`
   raises; asserts orchestrator prints yellow warning and does not re-raise
 
-### `tests/deduplication/test_orchestrator.py`
+### `tests/deduplication/test_branch_orchestrator.py`
 
 - `test_create_temp_project_warns_on_settings_copy_failure` — same as above for the dedupe
   orchestrator

--- a/src/vibe_heal/cleanup/orchestrator.py
+++ b/src/vibe_heal/cleanup/orchestrator.py
@@ -238,6 +238,21 @@ class CleanupOrchestrator:
             user_email=user_email,
         )
         console.print(f"[dim]Created project: {temp_project.project_key}[/dim]")
+
+        try:
+            copied, inherited_count = await self.project_manager.copy_exclusion_settings(
+                source_key=self.config.sonarqube_project_key,
+                target_key=temp_project.project_key,
+            )
+            if copied:
+                console.print(f"[dim]Copied {len(copied)} exclusion setting(s): {', '.join(copied)}[/dim]")
+            if inherited_count:
+                console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
+            if not copied and not inherited_count:
+                console.print("[dim]No exclusion settings configured on source project[/dim]")
+        except Exception as e:
+            console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")
+
         return temp_project
 
     async def _check_files_for_issues(

--- a/src/vibe_heal/cleanup/orchestrator.py
+++ b/src/vibe_heal/cleanup/orchestrator.py
@@ -240,7 +240,7 @@ class CleanupOrchestrator:
         console.print(f"[dim]Created project: {temp_project.project_key}[/dim]")
 
         try:
-            copied, inherited_count = await self.project_manager.copy_exclusion_settings(
+            copied, inherited_count, failed_count = await self.project_manager.copy_exclusion_settings(
                 source_key=self.config.sonarqube_project_key,
                 target_key=temp_project.project_key,
             )
@@ -248,7 +248,9 @@ class CleanupOrchestrator:
                 console.print(f"[dim]Copied {len(copied)} exclusion setting(s): {', '.join(copied)}[/dim]")
             if inherited_count:
                 console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
-            if not copied and not inherited_count:
+            if failed_count:
+                console.print(f"[yellow]Warning: Failed to apply {failed_count} exclusion setting(s)[/yellow]")
+            if not copied and not inherited_count and not failed_count:
                 console.print("[dim]No exclusion settings configured on source project[/dim]")
         except SonarQubeError as e:
             console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")

--- a/src/vibe_heal/cleanup/orchestrator.py
+++ b/src/vibe_heal/cleanup/orchestrator.py
@@ -13,7 +13,7 @@ from vibe_heal.git.manager import GitManager
 from vibe_heal.orchestrator import VibeHealOrchestrator
 from vibe_heal.sonarqube.analysis_runner import AnalysisResult, AnalysisRunner
 from vibe_heal.sonarqube.client import SonarQubeClient
-from vibe_heal.sonarqube.exceptions import ComponentNotFoundError
+from vibe_heal.sonarqube.exceptions import ComponentNotFoundError, SonarQubeError
 from vibe_heal.sonarqube.project_manager import ProjectManager, TempProjectMetadata
 
 console = Console()
@@ -250,7 +250,7 @@ class CleanupOrchestrator:
                 console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
             if not copied and not inherited_count:
                 console.print("[dim]No exclusion settings configured on source project[/dim]")
-        except Exception as e:
+        except SonarQubeError as e:
             console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")
 
         return temp_project

--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -577,7 +577,7 @@ class DedupeBranchOrchestrator:
         Returns:
             DedupeBranchResult with success status and details
         """
-        temp_project: TempProjectMetadata | None = None
+        temp_project: "TempProjectMetadata | None" = None
         files_processed: list[FileDedupResult] = []
 
         try:
@@ -716,7 +716,7 @@ class DedupeBranchOrchestrator:
         user_email = self.branch_analyzer.get_user_email()
 
         self.console.print("\n[dim]Creating temporary SonarQube project...[/dim]")
-        temp_project: TempProjectMetadata = await self.project_manager.create_temp_project(
+        temp_project: "TempProjectMetadata" = await self.project_manager.create_temp_project(
             base_key=self.config.sonarqube_project_key,
             branch_name=branch_name,
             user_email=user_email,

--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -20,7 +20,7 @@ from vibe_heal.git import GitManager
 from vibe_heal.git.branch_analyzer import BranchAnalyzer
 from vibe_heal.models import FixSummary
 from vibe_heal.sonarqube.analysis_runner import AnalysisRunner
-from vibe_heal.sonarqube.exceptions import ComponentNotFoundError
+from vibe_heal.sonarqube.exceptions import ComponentNotFoundError, SonarQubeError
 from vibe_heal.sonarqube.project_manager import ProjectManager
 
 if TYPE_CHECKING:
@@ -735,7 +735,7 @@ class DedupeBranchOrchestrator:
                 self.console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
             if not copied and not inherited_count:
                 self.console.print("[dim]No exclusion settings configured on source project[/dim]")
-        except Exception as e:
+        except SonarQubeError as e:
             self.console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")
 
         return temp_project

--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -577,7 +577,7 @@ class DedupeBranchOrchestrator:
         Returns:
             DedupeBranchResult with success status and details
         """
-        temp_project: "TempProjectMetadata | None" = None
+        temp_project: TempProjectMetadata | None = None
         files_processed: list[FileDedupResult] = []
 
         try:
@@ -716,7 +716,7 @@ class DedupeBranchOrchestrator:
         user_email = self.branch_analyzer.get_user_email()
 
         self.console.print("\n[dim]Creating temporary SonarQube project...[/dim]")
-        temp_project: "TempProjectMetadata" = await self.project_manager.create_temp_project(
+        temp_project: TempProjectMetadata = await self.project_manager.create_temp_project(
             base_key=self.config.sonarqube_project_key,
             branch_name=branch_name,
             user_email=user_email,

--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -725,7 +725,7 @@ class DedupeBranchOrchestrator:
         self.console.print(f"[dim]Created project: {temp_project.project_key}[/dim]")
 
         try:
-            copied, inherited_count = await self.project_manager.copy_exclusion_settings(
+            copied, inherited_count, failed_count = await self.project_manager.copy_exclusion_settings(
                 source_key=self.config.sonarqube_project_key,
                 target_key=temp_project.project_key,
             )
@@ -733,7 +733,9 @@ class DedupeBranchOrchestrator:
                 self.console.print(f"[dim]Copied {len(copied)} exclusion setting(s): {', '.join(copied)}[/dim]")
             if inherited_count:
                 self.console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
-            if not copied and not inherited_count:
+            if failed_count:
+                self.console.print(f"[yellow]Warning: Failed to apply {failed_count} exclusion setting(s)[/yellow]")
+            if not copied and not inherited_count and not failed_count:
                 self.console.print("[dim]No exclusion settings configured on source project[/dim]")
         except SonarQubeError as e:
             self.console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")

--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -17,8 +17,11 @@ from vibe_heal.deduplication.processor import (
     DuplicationProcessor,
 )
 from vibe_heal.git import GitManager
+from vibe_heal.git.branch_analyzer import BranchAnalyzer
 from vibe_heal.models import FixSummary
+from vibe_heal.sonarqube.analysis_runner import AnalysisRunner
 from vibe_heal.sonarqube.exceptions import ComponentNotFoundError
+from vibe_heal.sonarqube.project_manager import ProjectManager
 
 if TYPE_CHECKING:
     from vibe_heal.sonarqube.client import SonarQubeClient
@@ -540,10 +543,6 @@ class DedupeBranchOrchestrator:
             client: SonarQube API client
             ai_tool: AI tool for fixing duplications
         """
-        from vibe_heal.git.branch_analyzer import BranchAnalyzer
-        from vibe_heal.sonarqube.analysis_runner import AnalysisRunner
-        from vibe_heal.sonarqube.project_manager import ProjectManager
-
         self.config = config
         self.client = client
         self.ai_tool = ai_tool
@@ -578,8 +577,6 @@ class DedupeBranchOrchestrator:
         Returns:
             DedupeBranchResult with success status and details
         """
-        from vibe_heal.sonarqube.project_manager import TempProjectMetadata
-
         temp_project: TempProjectMetadata | None = None
         files_processed: list[FileDedupResult] = []
 
@@ -715,8 +712,6 @@ class DedupeBranchOrchestrator:
         Returns:
             Temporary project metadata
         """
-        from vibe_heal.sonarqube.project_manager import TempProjectMetadata
-
         branch_name = self.branch_analyzer.get_current_branch()
         user_email = self.branch_analyzer.get_user_email()
 
@@ -728,6 +723,21 @@ class DedupeBranchOrchestrator:
         )
 
         self.console.print(f"[dim]Created project: {temp_project.project_key}[/dim]")
+
+        try:
+            copied, inherited_count = await self.project_manager.copy_exclusion_settings(
+                source_key=self.config.sonarqube_project_key,
+                target_key=temp_project.project_key,
+            )
+            if copied:
+                self.console.print(f"[dim]Copied {len(copied)} exclusion setting(s): {', '.join(copied)}[/dim]")
+            if inherited_count:
+                self.console.print(f"[dim]Skipped {inherited_count} inherited setting(s)[/dim]")
+            if not copied and not inherited_count:
+                self.console.print("[dim]No exclusion settings configured on source project[/dim]")
+        except Exception as e:
+            self.console.print(f"[yellow]Warning: Could not copy exclusion settings: {e}[/yellow]")
+
         return temp_project
 
     async def _cleanup_temp_project(self, temp_project: "TempProjectMetadata") -> None:

--- a/src/vibe_heal/sonarqube/client.py
+++ b/src/vibe_heal/sonarqube/client.py
@@ -385,3 +385,51 @@ class SonarQubeClient:
         # Response format: {"analyses": [...], "paging": {...}}
         analyses = data.get("analyses", [])
         return len(analyses)
+
+    async def get_project_settings(self, project_key: str) -> list[dict]:
+        """Get project settings from SonarQube.
+
+        Args:
+            project_key: Project key to get settings for
+
+        Returns:
+            List of setting dicts from the API response
+
+        Raises:
+            SonarQubeAuthError: Authentication failed
+            SonarQubeAPIError: API request failed
+        """
+        params = {
+            "component": project_key,
+        }
+
+        data = await self._request("GET", "/api/settings/values", params=params)
+        settings: list[dict[Any, Any]] = data.get("settings", [])
+        return settings
+
+    async def set_project_setting(
+        self,
+        project_key: str,
+        setting_key: str,
+        values: list[str],
+    ) -> None:
+        """Set a project setting in SonarQube.
+
+        Uses multi-value form since exclusion settings are always path-pattern lists.
+
+        Args:
+            project_key: Project key to set the setting on
+            setting_key: Setting key (e.g., "sonar.cpd.exclusions")
+            values: List of values for the setting
+
+        Raises:
+            SonarQubeAuthError: Authentication failed
+            SonarQubeAPIError: API request failed
+        """
+        params: dict[str, Any] = {
+            "component": project_key,
+            "key": setting_key,
+            "values": values,
+        }
+
+        await self._request("POST", "/api/settings/set", params=params)

--- a/src/vibe_heal/sonarqube/project_manager.py
+++ b/src/vibe_heal/sonarqube/project_manager.py
@@ -122,7 +122,7 @@ class ProjectManager:
         """
         return await self.client.project_exists(project_key)
 
-    async def copy_exclusion_settings(self, source_key: str, target_key: str) -> tuple[list[str], int]:
+    async def copy_exclusion_settings(self, source_key: str, target_key: str) -> tuple[list[str], int, int]:
         """Copy exclusion settings from source project to target project.
 
         Args:
@@ -130,16 +130,16 @@ class ProjectManager:
             target_key: Target project key to copy settings to
 
         Returns:
-            Tuple of (list of keys that were copied, count of inherited keys skipped)
+            Tuple of (list of keys that were copied, count of inherited keys skipped,
+            count of keys that failed to apply)
 
         Raises:
-            SonarQubeAPIError: If the API request fails
-            SonarQubeAuthError: If authentication fails
-            RuntimeError: If the client is not initialized
+            SonarQubeError: If fetching settings from the source project fails
         """
         settings = await self.client.get_project_settings(source_key)
         copied: list[str] = []
         inherited_count = 0
+        failed_count = 0
 
         for setting in settings:
             key = setting.get("key")
@@ -160,11 +160,12 @@ class ProjectManager:
                 await self.client.set_project_setting(target_key, key, values)
             except SonarQubeError as e:
                 logger.warning(f"Failed to set {key} on {target_key}: {e}")
+                failed_count += 1
                 continue
 
             copied.append(key)
 
-        return copied, inherited_count
+        return copied, inherited_count, failed_count
 
     def _normalize_setting_values(self, setting: dict) -> list[str]:
         """Normalize setting values to a list of strings.

--- a/src/vibe_heal/sonarqube/project_manager.py
+++ b/src/vibe_heal/sonarqube/project_manager.py
@@ -1,11 +1,15 @@
 """SonarQube project lifecycle management for temporary projects."""
 
+import logging
 import re
 from datetime import datetime, timezone
+from typing import ClassVar
 
 from pydantic import BaseModel
 
 from vibe_heal.sonarqube.client import SonarQubeClient
+
+logger = logging.getLogger(__name__)
 
 
 class TempProjectMetadata(BaseModel):
@@ -25,6 +29,15 @@ class ProjectManager:
     Creates uniquely named temporary projects for branch analysis and
     ensures proper cleanup even on errors.
     """
+
+    EXCLUSION_SETTINGS: ClassVar[tuple[str, ...]] = (
+        "sonar.exclusions",
+        "sonar.test.exclusions",
+        "sonar.coverage.exclusions",
+        "sonar.cpd.exclusions",
+        "sonar.inclusions",
+        "sonar.test.inclusions",
+    )
 
     def __init__(self, client: SonarQubeClient) -> None:
         """Initialize the ProjectManager.
@@ -107,6 +120,73 @@ class ProjectManager:
             SonarQubeAPIError: If API request fails
         """
         return await self.client.project_exists(project_key)
+
+    async def copy_exclusion_settings(self, source_key: str, target_key: str) -> tuple[list[str], int]:
+        """Copy exclusion settings from source project to target project.
+
+        Args:
+            source_key: Source project key to copy settings from
+            target_key: Target project key to copy settings to
+
+        Returns:
+            Tuple of (list of keys that were copied, count of inherited keys skipped)
+
+        Raises:
+            SonarQubeAPIError: If the fetch step fails
+        """
+        settings = await self.client.get_project_settings(source_key)
+        copied: list[str] = []
+        inherited_count = 0
+
+        for setting in settings:
+            key = setting.get("key")
+            inherited = setting.get("inherited", False)
+
+            if key not in self.EXCLUSION_SETTINGS:
+                continue
+
+            if inherited:
+                inherited_count += 1
+                continue
+
+            values = self._normalize_setting_values(setting)
+            if not values:
+                continue
+
+            try:
+                await self.client.set_project_setting(target_key, key, values)
+            except Exception as e:
+                logger.warning(f"Failed to set {key} on {target_key}: {e}")
+                continue
+
+            copied.append(key)
+
+        return copied, inherited_count
+
+    def _normalize_setting_values(self, setting: dict) -> list[str]:
+        """Normalize setting values to a list of strings.
+
+        Handles both scalar ('value') and multi-value ('values') shapes.
+
+        Args:
+            setting: Raw setting dict from the API
+
+        Returns:
+            List of string values
+        """
+        if "values" in setting:
+            vals = setting["values"]
+            if isinstance(vals, list):
+                return [str(v) for v in vals]
+            return [str(vals)]
+        if "value" in setting:
+            val = setting["value"]
+            if val is None:
+                return []
+            if isinstance(val, list):
+                return [str(v) for v in val]
+            return [str(val)]
+        return []
 
     def _sanitize_identifier(self, value: str) -> str:
         """Sanitize string for use in project key.

--- a/src/vibe_heal/sonarqube/project_manager.py
+++ b/src/vibe_heal/sonarqube/project_manager.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from pydantic import BaseModel
 
 from vibe_heal.sonarqube.client import SonarQubeClient
+from vibe_heal.sonarqube.exceptions import SonarQubeError
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +133,9 @@ class ProjectManager:
             Tuple of (list of keys that were copied, count of inherited keys skipped)
 
         Raises:
-            SonarQubeAPIError: If the fetch step fails
+            SonarQubeAPIError: If the API request fails
+            SonarQubeAuthError: If authentication fails
+            RuntimeError: If the client is not initialized
         """
         settings = await self.client.get_project_settings(source_key)
         copied: list[str] = []
@@ -155,7 +158,7 @@ class ProjectManager:
 
             try:
                 await self.client.set_project_setting(target_key, key, values)
-            except Exception as e:
+            except SonarQubeError as e:
                 logger.warning(f"Failed to set {key} on {target_key}: {e}")
                 continue
 

--- a/tests/cleanup/test_orchestrator.py
+++ b/tests/cleanup/test_orchestrator.py
@@ -301,3 +301,79 @@ class TestFilterFiles:
         result = orchestrator._filter_files(files, ["*.py"])
 
         assert len(result) == 3
+
+
+class TestCreateTempProject:
+    """Tests for _create_temp_project method."""
+
+    @pytest.mark.asyncio
+    async def test_create_temp_project_warns_on_settings_copy_failure(
+        self,
+        orchestrator: CleanupOrchestrator,
+        temp_project: TempProjectMetadata,
+    ) -> None:
+        """Test that the orchestrator warns but does not re-raise when copying settings fails."""
+        from vibe_heal.sonarqube.exceptions import SonarQubeAPIError
+
+        with (
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_current_branch",
+                return_value="feature-branch",
+            ),
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_user_email",
+                return_value="user@example.com",
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "create_temp_project",
+                return_value=temp_project,
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "copy_exclusion_settings",
+                side_effect=SonarQubeAPIError("Permission denied", status_code=403),
+            ),
+        ):
+            result = await orchestrator._create_temp_project()
+
+        assert result == temp_project
+
+    @pytest.mark.asyncio
+    async def test_create_temp_project_copies_settings_successfully(
+        self,
+        orchestrator: CleanupOrchestrator,
+        temp_project: TempProjectMetadata,
+    ) -> None:
+        """Test that settings are copied successfully after project creation."""
+        with (
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_current_branch",
+                return_value="feature-branch",
+            ),
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_user_email",
+                return_value="user@example.com",
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "create_temp_project",
+                return_value=temp_project,
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "copy_exclusion_settings",
+                return_value=(["sonar.cpd.exclusions"], 0),
+            ) as mock_copy,
+        ):
+            result = await orchestrator._create_temp_project()
+
+        assert result == temp_project
+        mock_copy.assert_called_once_with(
+            source_key=orchestrator.config.sonarqube_project_key,
+            target_key=temp_project.project_key,
+        )

--- a/tests/cleanup/test_orchestrator.py
+++ b/tests/cleanup/test_orchestrator.py
@@ -367,7 +367,7 @@ class TestCreateTempProject:
             patch.object(
                 orchestrator.project_manager,
                 "copy_exclusion_settings",
-                return_value=(["sonar.cpd.exclusions"], 0),
+                return_value=(["sonar.cpd.exclusions"], 0, 0),
             ) as mock_copy,
         ):
             result = await orchestrator._create_temp_project()

--- a/tests/deduplication/__init__.py
+++ b/tests/deduplication/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for deduplication module."""

--- a/tests/deduplication/test_branch_orchestrator.py
+++ b/tests/deduplication/test_branch_orchestrator.py
@@ -1,0 +1,131 @@
+"""Tests for DedupeBranchOrchestrator class."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from vibe_heal.ai_tools.base import AITool
+from vibe_heal.config import VibeHealConfig
+from vibe_heal.deduplication.orchestrator import DedupeBranchOrchestrator
+from vibe_heal.sonarqube.client import SonarQubeClient
+from vibe_heal.sonarqube.exceptions import SonarQubeAPIError
+from vibe_heal.sonarqube.project_manager import TempProjectMetadata
+
+
+@pytest.fixture
+def config() -> VibeHealConfig:
+    """Create test configuration."""
+    return VibeHealConfig(
+        sonarqube_url="https://sonar.test.com",
+        sonarqube_token="test-token",
+        sonarqube_project_key="my-project",
+    )
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Create a mock SonarQubeClient."""
+    return AsyncMock(spec=SonarQubeClient)
+
+
+@pytest.fixture
+def mock_ai_tool() -> MagicMock:
+    """Create a mock AITool."""
+    return MagicMock(spec=AITool)
+
+
+@pytest.fixture
+def orchestrator(
+    config: VibeHealConfig,
+    mock_client: AsyncMock,
+    mock_ai_tool: MagicMock,
+) -> DedupeBranchOrchestrator:
+    """Create DedupeBranchOrchestrator with mocked dependencies."""
+    return DedupeBranchOrchestrator(config, mock_client, mock_ai_tool)
+
+
+@pytest.fixture
+def temp_project() -> TempProjectMetadata:
+    """Create a test temporary project metadata."""
+    return TempProjectMetadata(
+        project_key="test-project-user_example_com-feature",
+        project_name="Test Project (user@example.com - feature)",
+        created_at="2024-01-01T00:00:00Z",
+        base_project_key="test-project",
+        branch_name="feature",
+        user_email="user@example.com",
+    )
+
+
+class TestCreateTempProject:
+    """Tests for _create_temp_project method."""
+
+    @pytest.mark.asyncio
+    async def test_create_temp_project_warns_on_settings_copy_failure(
+        self,
+        orchestrator: DedupeBranchOrchestrator,
+        temp_project: TempProjectMetadata,
+    ) -> None:
+        """Test that the orchestrator warns but does not re-raise when copying settings fails."""
+        with (
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_current_branch",
+                return_value="feature-branch",
+            ),
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_user_email",
+                return_value="user@example.com",
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "create_temp_project",
+                return_value=temp_project,
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "copy_exclusion_settings",
+                side_effect=SonarQubeAPIError("Permission denied", status_code=403),
+            ),
+        ):
+            result = await orchestrator._create_temp_project()
+
+        assert result == temp_project
+
+    @pytest.mark.asyncio
+    async def test_create_temp_project_copies_settings_successfully(
+        self,
+        orchestrator: DedupeBranchOrchestrator,
+        temp_project: TempProjectMetadata,
+    ) -> None:
+        """Test that settings are copied successfully after project creation."""
+        with (
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_current_branch",
+                return_value="feature-branch",
+            ),
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_user_email",
+                return_value="user@example.com",
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "create_temp_project",
+                return_value=temp_project,
+            ),
+            patch.object(
+                orchestrator.project_manager,
+                "copy_exclusion_settings",
+                return_value=(["sonar.cpd.exclusions"], 0),
+            ) as mock_copy,
+        ):
+            result = await orchestrator._create_temp_project()
+
+        assert result == temp_project
+        mock_copy.assert_called_once_with(
+            source_key=orchestrator.config.sonarqube_project_key,
+            target_key=temp_project.project_key,
+        )

--- a/tests/deduplication/test_branch_orchestrator.py
+++ b/tests/deduplication/test_branch_orchestrator.py
@@ -119,7 +119,7 @@ class TestCreateTempProject:
             patch.object(
                 orchestrator.project_manager,
                 "copy_exclusion_settings",
-                return_value=(["sonar.cpd.exclusions"], 0),
+                return_value=(["sonar.cpd.exclusions"], 0, 0),
             ) as mock_copy,
         ):
             result = await orchestrator._create_temp_project()

--- a/tests/sonarqube/test_client.py
+++ b/tests/sonarqube/test_client.py
@@ -442,3 +442,61 @@ class TestSonarQubeClient:
 
         assert route.called
         assert route.calls.last.request.url.params["projects"] == "my-test-project"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_project_settings(self, config: VibeHealConfig) -> None:
+        """Test getting project settings for both scalar and multi-value shapes."""
+        response_data = {
+            "settings": [
+                {"key": "sonar.cpd.exclusions", "value": "**/generated/**", "inherited": False},
+                {"key": "sonar.exclusions", "values": ["**/*.gen.ts", "tests/**"], "inherited": False},
+                {"key": "sonar.qualitygate", "value": "default", "inherited": True},
+            ]
+        }
+        route = respx.get("https://sonar.test.com/api/settings/values").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+
+        async with SonarQubeClient(config) as client:
+            settings = await client.get_project_settings("my-project")
+
+        assert len(settings) == 3
+        assert settings[0]["key"] == "sonar.cpd.exclusions"
+        assert settings[0]["value"] == "**/generated/**"
+        assert settings[1]["key"] == "sonar.exclusions"
+        assert settings[1]["values"] == ["**/*.gen.ts", "tests/**"]
+        assert route.called
+        assert route.calls.last.request.url.params["component"] == "my-project"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_project_settings_empty(self, config: VibeHealConfig) -> None:
+        """Test getting project settings when none are set."""
+        response_data = {"settings": []}
+        route = respx.get("https://sonar.test.com/api/settings/values").mock(
+            return_value=httpx.Response(200, json=response_data)
+        )
+
+        async with SonarQubeClient(config) as client:
+            settings = await client.get_project_settings("my-project")
+
+        assert settings == []
+        assert route.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_set_project_setting(self, config: VibeHealConfig) -> None:
+        """Test setting a project setting with multi-value form."""
+        route = respx.post("https://sonar.test.com/api/settings/set").mock(return_value=httpx.Response(200, json={}))
+
+        async with SonarQubeClient(config) as client:
+            await client.set_project_setting(
+                "target-project", "sonar.cpd.exclusions", ["**/generated/**", "**/*.gen.ts"]
+            )
+
+        assert route.called
+        req = route.calls.last.request
+        assert req.url.params["component"] == "target-project"
+        assert req.url.params["key"] == "sonar.cpd.exclusions"
+        assert req.url.params.get_list("values") == ["**/generated/**", "**/*.gen.ts"]

--- a/tests/sonarqube/test_project_manager.py
+++ b/tests/sonarqube/test_project_manager.py
@@ -296,3 +296,123 @@ class TestTempProjectMetadata:
                 base_project_key="base",
                 branch_name="main",
             )
+
+
+class TestCopyExclusionSettings:
+    """Tests for copy_exclusion_settings method."""
+
+    def test_exclusion_settings_constant(self) -> None:
+        """Test that EXCLUSION_SETTINGS constant has expected values."""
+        expected = (
+            "sonar.exclusions",
+            "sonar.test.exclusions",
+            "sonar.coverage.exclusions",
+            "sonar.cpd.exclusions",
+            "sonar.inclusions",
+            "sonar.test.inclusions",
+        )
+        assert expected == ProjectManager.EXCLUSION_SETTINGS
+
+    @pytest.mark.asyncio
+    async def test_copy_exclusion_settings_copies_non_inherited(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        """Test that only non-inherited exclusion settings are copied."""
+        settings = [
+            {"key": "sonar.exclusions", "value": "**/vendor/**", "inherited": False},
+            {"key": "sonar.test.exclusions", "values": ["tests/**"], "inherited": False},
+            {"key": "sonar.coverage.exclusions", "value": "src/gen/**", "inherited": True},
+            {"key": "sonar.cpd.exclusions", "value": "**/generated/**", "inherited": False},
+            {"key": "sonar.inclusions", "values": ["src/**/*.py"], "inherited": True},
+            {"key": "sonar.test.inclusions", "value": "tests/**/*.py", "inherited": False},
+            {"key": "sonar.qualitygate", "value": "default", "inherited": False},
+        ]
+        mock_client.get_project_settings = AsyncMock(return_value=settings)
+        mock_client.set_project_setting = AsyncMock()
+
+        copied, inherited_count = await project_manager.copy_exclusion_settings("source-project", "target-project")
+
+        assert sorted(copied) == sorted([
+            "sonar.exclusions",
+            "sonar.test.exclusions",
+            "sonar.cpd.exclusions",
+            "sonar.test.inclusions",
+        ])
+        assert inherited_count == 2
+        assert mock_client.set_project_setting.call_count == 4
+        mock_client.set_project_setting.assert_any_call("target-project", "sonar.exclusions", ["**/vendor/**"])
+        mock_client.set_project_setting.assert_any_call("target-project", "sonar.test.exclusions", ["tests/**"])
+        mock_client.set_project_setting.assert_any_call("target-project", "sonar.cpd.exclusions", ["**/generated/**"])
+        mock_client.set_project_setting.assert_any_call("target-project", "sonar.test.inclusions", ["tests/**/*.py"])
+
+    @pytest.mark.asyncio
+    async def test_copy_exclusion_settings_returns_empty_when_none_match(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        """Test that empty list is returned when no exclusion settings are found."""
+        settings = [
+            {"key": "sonar.qualitygate", "value": "default", "inherited": False},
+            {"key": "sonar.javascript.lcov.reportPaths", "value": "coverage/lcov.info", "inherited": False},
+        ]
+        mock_client.get_project_settings = AsyncMock(return_value=settings)
+        mock_client.set_project_setting = AsyncMock()
+
+        copied, inherited_count = await project_manager.copy_exclusion_settings("source-project", "target-project")
+
+        assert copied == []
+        assert inherited_count == 0
+        mock_client.set_project_setting.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_copy_exclusion_settings_raises_if_fetch_fails(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        """Test that the error propagates if fetching settings fails."""
+        mock_client.get_project_settings = AsyncMock(
+            side_effect=SonarQubeAPIError("Permission denied", status_code=403)
+        )
+
+        with pytest.raises(SonarQubeAPIError, match="Permission denied"):
+            await project_manager.copy_exclusion_settings("source-project", "target-project")
+
+    @pytest.mark.asyncio
+    async def test_copy_exclusion_settings_skips_failed_set(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        """Test that individual set failures are logged and skipped."""
+        settings = [
+            {"key": "sonar.cpd.exclusions", "value": "**/generated/**", "inherited": False},
+            {"key": "sonar.exclusions", "value": "**/*.gen.ts", "inherited": False},
+        ]
+        mock_client.get_project_settings = AsyncMock(return_value=settings)
+        mock_client.set_project_setting = AsyncMock(side_effect=[SonarQubeAPIError("Failed"), None])
+
+        copied, inherited_count = await project_manager.copy_exclusion_settings("source-project", "target-project")
+
+        assert copied == ["sonar.exclusions"]
+        assert inherited_count == 0
+        assert mock_client.set_project_setting.call_count == 2
+
+    def test_normalize_setting_values_scalar(self, project_manager: ProjectManager) -> None:
+        """Test normalization of scalar setting values."""
+        setting = {"key": "sonar.cpd.exclusions", "value": "**/generated/**"}
+        result = project_manager._normalize_setting_values(setting)
+        assert result == ["**/generated/**"]
+
+    def test_normalize_setting_values_list(self, project_manager: ProjectManager) -> None:
+        """Test normalization of multi-value setting values."""
+        setting = {"key": "sonar.exclusions", "values": ["**/*.gen.ts", "tests/**"]}
+        result = project_manager._normalize_setting_values(setting)
+        assert result == ["**/*.gen.ts", "tests/**"]
+
+    def test_normalize_setting_values_none(self, project_manager: ProjectManager) -> None:
+        """Test normalization of setting with None value."""
+        setting = {"key": "sonar.exclusions", "value": None}
+        result = project_manager._normalize_setting_values(setting)
+        assert result == []
+
+    def test_normalize_setting_values_empty(self, project_manager: ProjectManager) -> None:
+        """Test normalization of setting with no value fields."""
+        setting = {"key": "sonar.exclusions"}
+        result = project_manager._normalize_setting_values(setting)
+        assert result == []

--- a/tests/sonarqube/test_project_manager.py
+++ b/tests/sonarqube/test_project_manager.py
@@ -330,7 +330,9 @@ class TestCopyExclusionSettings:
         mock_client.get_project_settings = AsyncMock(return_value=settings)
         mock_client.set_project_setting = AsyncMock()
 
-        copied, inherited_count = await project_manager.copy_exclusion_settings("source-project", "target-project")
+        copied, inherited_count, failed_count = await project_manager.copy_exclusion_settings(
+            "source-project", "target-project"
+        )
 
         assert sorted(copied) == sorted([
             "sonar.exclusions",
@@ -339,6 +341,7 @@ class TestCopyExclusionSettings:
             "sonar.test.inclusions",
         ])
         assert inherited_count == 2
+        assert failed_count == 0
         assert mock_client.set_project_setting.call_count == 4
         mock_client.set_project_setting.assert_any_call("target-project", "sonar.exclusions", ["**/vendor/**"])
         mock_client.set_project_setting.assert_any_call("target-project", "sonar.test.exclusions", ["tests/**"])
@@ -357,10 +360,13 @@ class TestCopyExclusionSettings:
         mock_client.get_project_settings = AsyncMock(return_value=settings)
         mock_client.set_project_setting = AsyncMock()
 
-        copied, inherited_count = await project_manager.copy_exclusion_settings("source-project", "target-project")
+        copied, inherited_count, failed_count = await project_manager.copy_exclusion_settings(
+            "source-project", "target-project"
+        )
 
         assert copied == []
         assert inherited_count == 0
+        assert failed_count == 0
         mock_client.set_project_setting.assert_not_called()
 
     @pytest.mark.asyncio
@@ -387,10 +393,13 @@ class TestCopyExclusionSettings:
         mock_client.get_project_settings = AsyncMock(return_value=settings)
         mock_client.set_project_setting = AsyncMock(side_effect=[SonarQubeAPIError("Failed"), None])
 
-        copied, inherited_count = await project_manager.copy_exclusion_settings("source-project", "target-project")
+        copied, inherited_count, failed_count = await project_manager.copy_exclusion_settings(
+            "source-project", "target-project"
+        )
 
         assert copied == ["sonar.exclusions"]
         assert inherited_count == 0
+        assert failed_count == 1
         assert mock_client.set_project_setting.call_count == 2
 
     def test_normalize_setting_values_scalar(self, project_manager: ProjectManager) -> None:


### PR DESCRIPTION
When cleanup or dedupe-branch creates a temporary SonarQube project, the
blank project had no exclusion settings, causing false-positive duplication
and coverage issues on files the source project intentionally excludes.

Add get_project_settings() and set_project_setting() to SonarQubeClient,
and copy_exclusion_settings(source_key, target_key) to ProjectManager.
The method reads sonar.exclusions, sonar.test.exclusions,
sonar.coverage.exclusions, sonar.cpd.exclusions, sonar.inclusions, and
sonar.test.inclusions from the source project — skipping inherited settings
— and applies them to the temporary project immediately after creation.

Both CleanupOrchestrator and DedupeBranchOrchestrator call this step with
warn-and-continue semantics: API failures (permissions, older SonarQube
versions) print a yellow warning and proceed rather than aborting the run.