### PR TITLE
feat: honor sonar-project.properties in all sonar-scanner commands

### DIFF
--- a/docs/superpowers/plans/2026-05-21-sonar-properties-file.md
+++ b/docs/superpowers/plans/2026-05-21-sonar-properties-file.md
@@ -1,0 +1,1197 @@
+# sonar-project.properties Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `sonar-project.properties` exists in the project directory, use it as the source of truth for scanner configuration — patching the project key/name in place for temp-project runs and letting the file govern all other settings.
+
+**Architecture:** A new `SonarPropertiesHandler` class in `sonarqube/properties_handler.py` owns both command building (minimal vs. full `-D` flags) and file patching (context manager that writes then restores). `AnalysisRunner` delegates to it. `ProjectManager.create_temp_project` gains a `command_name` parameter and generates a human-readable display name.
+
+**Tech Stack:** Python 3.11+, `contextlib.contextmanager`, `re`, `os.environ`, `pathlib.Path`, pytest + `tmp_path` + `monkeypatch`.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/vibe_heal/sonarqube/properties_handler.py` | `SonarPropertiesHandler` class + `_patch_content` helper |
+| Create | `tests/sonarqube/test_properties_handler.py` | All tests for the new module |
+| Modify | `src/vibe_heal/sonarqube/analysis_runner.py` | Use handler; remove `_get_scanner_command`; add auth hint |
+| Modify | `tests/sonarqube/test_analysis_runner.py` | Remove `TestGetScannerCommand`; add auth-hint tests |
+| Modify | `src/vibe_heal/sonarqube/project_manager.py` | Add `command_name` param; human-readable name |
+| Modify | `tests/sonarqube/test_project_manager.py` | Update name assertions; add name-format test |
+| Modify | `src/vibe_heal/review/orchestrator.py` | Pass `command_name="review"` |
+| Modify | `src/vibe_heal/cleanup/orchestrator.py` | Pass `command_name="cleanup"` |
+| Modify | `src/vibe_heal/deduplication/orchestrator.py` | Pass `command_name="dedupe-branch"` |
+
+---
+
+## Task 1: `SonarPropertiesHandler` — `exists` and `build_command` (no-file path)
+
+This task creates the file and implements the path that mirrors the current `AnalysisRunner._get_scanner_command` behaviour. The no-file path is identical to today, so existing callers regress to nothing.
+
+**Files:**
+- Create: `src/vibe_heal/sonarqube/properties_handler.py`
+- Create: `tests/sonarqube/test_properties_handler.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/sonarqube/test_properties_handler.py`:
+
+```python
+"""Tests for SonarPropertiesHandler."""
+
+from pathlib import Path
+
+import pytest
+
+from vibe_heal.config import VibeHealConfig
+from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler
+
+
+@pytest.fixture
+def config() -> VibeHealConfig:
+    return VibeHealConfig(
+        sonarqube_url="https://sonar.test.com",
+        sonarqube_token="test-token",
+        sonarqube_project_key="my-project",
+    )
+
+
+@pytest.fixture
+def basic_auth_config() -> VibeHealConfig:
+    return VibeHealConfig(
+        sonarqube_url="https://sonar.test.com",
+        sonarqube_username="user",
+        sonarqube_password="pass",
+        sonarqube_project_key="my-project",
+    )
+
+
+class TestExists:
+    def test_false_when_file_absent(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler.exists is False
+
+    def test_true_when_file_present(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=x\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler.exists is True
+
+
+class TestBuildCommandNoFile:
+    def test_includes_all_d_flags_token_auth(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("test-key", "Test Project", tmp_path)
+        assert "-Dsonar.projectKey=test-key" in cmd
+        assert "-Dsonar.projectName=Test Project" in cmd
+        assert "-Dsonar.host.url=https://sonar.test.com" in cmd
+        assert "-Dsonar.token=test-token" in cmd
+        assert "-Dsonar.sources=." in cmd
+
+    def test_default_sources_dot(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("key", "Name", tmp_path, sources=None)
+        assert "-Dsonar.sources=." in cmd
+
+    def test_explicit_sources(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("key", "Name", tmp_path, sources=[Path("src/a.py"), Path("src/b.py")])
+        assert "-Dsonar.sources=src/a.py,src/b.py" in cmd
+
+    def test_basic_auth(self, tmp_path: Path, basic_auth_config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, basic_auth_config)
+        cmd = handler.build_command("key", "Name", tmp_path)
+        assert "-Dsonar.login=user" in cmd
+        assert "-Dsonar.password=pass" in cmd
+        assert not any("sonar.token" in arg for arg in cmd)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/sonarqube/test_properties_handler.py -v
+```
+
+Expected: `ModuleNotFoundError` or `ImportError` — file does not exist yet.
+
+- [ ] **Step 3: Create `properties_handler.py` with `exists` and `build_command` (no-file path)**
+
+Create `src/vibe_heal/sonarqube/properties_handler.py`:
+
+```python
+"""sonar-project.properties detection, command building, and file patching."""
+
+import logging
+import os
+import re
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+from vibe_heal.config import VibeHealConfig
+
+logger = logging.getLogger(__name__)
+
+PROPERTIES_FILENAME = "sonar-project.properties"
+
+_KEY_RE = re.compile(r"^\s*sonar\.projectKey\s*=", re.IGNORECASE)
+_NAME_RE = re.compile(r"^\s*sonar\.projectName\s*=", re.IGNORECASE)
+_AUTH_PROPS_RE = re.compile(r"^\s*sonar\.(token|login|password)\s*=\s*.+", re.IGNORECASE)
+_AUTH_ENV_VARS = ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN")
+
+
+class SonarPropertiesHandler:
+    """Detects sonar-project.properties, builds scanner commands, and patches the file for temp projects."""
+
+    def __init__(self, project_dir: Path, config: VibeHealConfig) -> None:
+        self.project_dir = project_dir
+        self.config = config
+        self.properties_file = project_dir / PROPERTIES_FILENAME
+
+    @property
+    def exists(self) -> bool:
+        return self.properties_file.exists()
+
+    def build_command(
+        self,
+        project_key: str,
+        project_name: str,
+        project_dir: Path,
+        sources: list[Path] | None = None,
+    ) -> list[str]:
+        if not self.exists:
+            return self._build_full_command(project_key, project_name, project_dir, sources)
+        command = ["sonar-scanner"]
+        if not self._has_auth_configured():
+            if self.config.use_token_auth:
+                command.append(f"-Dsonar.token={self.config.sonarqube_token}")
+            else:
+                command.append(f"-Dsonar.login={self.config.sonarqube_username}")
+                command.append(f"-Dsonar.password={self.config.sonarqube_password}")
+        return command
+
+    def _build_full_command(
+        self,
+        project_key: str,
+        project_name: str,
+        project_dir: Path,
+        sources: list[Path] | None = None,
+    ) -> list[str]:
+        command = [
+            "sonar-scanner",
+            f"-Dsonar.projectKey={project_key}",
+            f"-Dsonar.projectName={project_name}",
+            f"-Dsonar.host.url={self.config.sonarqube_url}",
+        ]
+        if self.config.use_token_auth:
+            command.append(f"-Dsonar.token={self.config.sonarqube_token}")
+        else:
+            command.append(f"-Dsonar.login={self.config.sonarqube_username}")
+            command.append(f"-Dsonar.password={self.config.sonarqube_password}")
+        if sources:
+            command.append(f"-Dsonar.sources={','.join(str(s) for s in sources)}")
+        else:
+            command.append("-Dsonar.sources=.")
+        return command
+
+    def _has_auth_configured(self) -> bool:
+        for env_var in _AUTH_ENV_VARS:
+            if os.environ.get(env_var):
+                return True
+        if self.exists:
+            content = self.properties_file.read_text(encoding="utf-8")
+            for line in content.splitlines():
+                if line.lstrip().startswith("#"):
+                    continue
+                if _AUTH_PROPS_RE.match(line):
+                    return True
+        return False
+
+    def _extract_property(self, content: str, key: str) -> str | None:
+        pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.*)", re.IGNORECASE)
+        for line in content.splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            m = pattern.match(line)
+            if m:
+                return m.group(1).strip()
+        return None
+
+    @contextmanager
+    def patched(self, project_key: str, project_name: str) -> Generator[None, None, None]:
+        if not self.exists:
+            yield
+            return
+        original_content = self.properties_file.read_text(encoding="utf-8")
+        existing_key = self._extract_property(original_content, "sonar.projectKey")
+        if existing_key == project_key:
+            yield
+            return
+        patched_content = _patch_content(original_content, project_key, project_name)
+        self.properties_file.write_text(patched_content, encoding="utf-8")
+        try:
+            yield
+        finally:
+            try:
+                self.properties_file.write_text(original_content, encoding="utf-8")
+            except OSError:
+                logger.error(
+                    "Failed to restore %s. Original content:\n%s",
+                    self.properties_file,
+                    original_content,
+                )
+
+
+def _patch_content(content: str, new_key: str, new_name: str) -> str:
+    lines = content.splitlines(keepends=True)
+    key_idx: int | None = None
+    name_idx: int | None = None
+    orig_key_line: str | None = None
+    orig_name_line: str | None = None
+
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("#"):
+            continue
+        if _KEY_RE.match(line) and key_idx is None:
+            key_idx = i
+            orig_key_line = line.rstrip("\n").rstrip("\r")
+        elif _NAME_RE.match(line) and name_idx is None:
+            name_idx = i
+            orig_name_line = line.rstrip("\n").rstrip("\r")
+
+    recovery: list[str] = [
+        "# vibe-heal: temporary analysis project. If this process was interrupted,\n",
+        "# restore the lines below (remove the '#' prefix):\n",
+    ]
+    if orig_key_line is not None:
+        recovery.append(f"# {orig_key_line.lstrip()}\n")
+    if orig_name_line is not None:
+        recovery.append(f"# {orig_name_line.lstrip()}\n")
+    recovery.append(f"sonar.projectKey={new_key}\n")
+    recovery.append(f"sonar.projectName={new_name}\n")
+
+    present = [i for i in (key_idx, name_idx) if i is not None]
+    if not present:
+        return content + f"sonar.projectKey={new_key}\n" + f"sonar.projectName={new_name}\n"
+
+    first_idx = min(present)
+    skip = set(present)
+    result: list[str] = []
+    for i, line in enumerate(lines):
+        if i == first_idx:
+            result.extend(recovery)
+        if i not in skip:
+            result.append(line)
+    return "".join(result)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/sonarqube/test_properties_handler.py::TestExists tests/sonarqube/test_properties_handler.py::TestBuildCommandNoFile -v
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vibe_heal/sonarqube/properties_handler.py tests/sonarqube/test_properties_handler.py
+git commit -m "feat: add SonarPropertiesHandler with exists and full-command build"
+```
+
+---
+
+## Task 2: `SonarPropertiesHandler` — auth detection and minimal command (properties file path)
+
+**Files:**
+- Modify: `tests/sonarqube/test_properties_handler.py`
+- (no source change needed — `_has_auth_configured` and minimal-command path are already in the file from Task 1)
+
+- [ ] **Step 1: Add failing tests for auth detection and minimal command**
+
+Append to `tests/sonarqube/test_properties_handler.py`:
+
+```python
+class TestHasAuthConfigured:
+    def test_false_when_nothing_set(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is False
+
+    def test_true_via_sonar_token_env(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "secret")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_sonarqube_token_env(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SONARQUBE_TOKEN", "secret")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_sonar_login_env(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SONAR_LOGIN", "user")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_token_in_file(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.token=file-token\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_login_in_file(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.login=user\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_commented_token_line_not_counted(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("# sonar.token=commented\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is False
+
+
+class TestBuildCommandWithFile:
+    def test_minimal_command_when_auth_in_file(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text(
+            "sonar.projectKey=orig\nsonar.token=file-token\n"
+        )
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name", tmp_path)
+        assert cmd == ["sonar-scanner"]
+
+    def test_minimal_command_when_auth_in_env(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "env-token")
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name", tmp_path)
+        assert cmd == ["sonar-scanner"]
+
+    def test_injects_token_fallback_when_no_auth(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name", tmp_path)
+        assert cmd == ["sonar-scanner", "-Dsonar.token=test-token"]
+
+    def test_injects_basic_auth_fallback_when_no_auth(self, tmp_path: Path, basic_auth_config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, basic_auth_config)
+        cmd = handler.build_command("temp-key", "Temp Name", tmp_path)
+        assert cmd == ["sonar-scanner", "-Dsonar.login=user", "-Dsonar.password=pass"]
+
+    def test_sources_not_injected_when_file_present(self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "tok")
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("key", "Name", tmp_path, sources=[Path("src/a.py")])
+        assert not any("sonar.sources" in arg for arg in cmd)
+```
+
+- [ ] **Step 2: Run tests to verify they pass (implementation is already complete from Task 1)**
+
+```bash
+uv run pytest tests/sonarqube/test_properties_handler.py::TestHasAuthConfigured tests/sonarqube/test_properties_handler.py::TestBuildCommandWithFile -v
+```
+
+Expected: all 11 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/sonarqube/test_properties_handler.py
+git commit -m "test: add auth detection and minimal command tests for SonarPropertiesHandler"
+```
+
+---
+
+## Task 3: `SonarPropertiesHandler` — `_patch_content` and `patched` context manager
+
+**Files:**
+- Modify: `tests/sonarqube/test_properties_handler.py`
+- (implementation already in file from Task 1)
+
+- [ ] **Step 1: Add failing tests for `_patch_content` and `patched`**
+
+Append to `tests/sonarqube/test_properties_handler.py`:
+
+```python
+from vibe_heal.sonarqube.properties_handler import _patch_content
+
+
+class TestPatchContent:
+    def test_replaces_key_and_name_with_recovery_block(self) -> None:
+        original = "sonar.projectKey=my-project\nsonar.projectName=My Project\nsonar.sources=.\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        assert "sonar.projectKey=temp-key-123" in result
+        assert "sonar.projectName=my-project review user main" in result
+        assert "# sonar.projectKey=my-project" in result
+        assert "# sonar.projectName=My Project" in result
+        assert "vibe-heal: temporary analysis project" in result
+        assert "sonar.sources=." in result  # unrelated line preserved
+
+    def test_key_only_in_file_appends_new_name(self) -> None:
+        original = "sonar.projectKey=my-project\nsonar.sources=.\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        assert "sonar.projectKey=temp-key-123" in result
+        assert "sonar.projectName=my-project review user main" in result
+        assert "# sonar.projectKey=my-project" in result
+        assert "sonar.sources=." in result
+
+    def test_neither_key_nor_name_appended_at_end(self) -> None:
+        original = "sonar.sources=.\nsonar.host.url=https://sonar.test.com\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        assert result.endswith("sonar.projectKey=temp-key-123\nsonar.projectName=my-project review user main\n")
+        assert "sonar.sources=." in result
+
+    def test_commented_key_line_not_treated_as_property(self) -> None:
+        original = "# sonar.projectKey=commented\nsonar.sources=.\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        # No recovery block since no real key was found, just appended
+        assert result.endswith("sonar.projectKey=temp-key-123\nsonar.projectName=my-project review user main\n")
+
+
+class TestPatched:
+    def test_patches_file_during_with_block(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        props = tmp_path / "sonar-project.properties"
+        props.write_text("sonar.projectKey=original\nsonar.sources=.\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("temp-key", "Temp Name"):
+            content = props.read_text()
+            assert "sonar.projectKey=temp-key" in content
+            assert "# sonar.projectKey=original" in content
+
+    def test_restores_file_after_normal_exit(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        original = "sonar.projectKey=original\nsonar.sources=.\n"
+        props = tmp_path / "sonar-project.properties"
+        props.write_text(original)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("temp-key", "Temp Name"):
+            pass
+        assert props.read_text() == original
+
+    def test_restores_file_after_exception(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        original = "sonar.projectKey=original\nsonar.sources=.\n"
+        props = tmp_path / "sonar-project.properties"
+        props.write_text(original)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with pytest.raises(ValueError):
+            with handler.patched("temp-key", "Temp Name"):
+                raise ValueError("simulated failure")
+        assert props.read_text() == original
+
+    def test_noop_when_file_absent(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("temp-key", "Temp Name"):
+            pass  # must not raise
+
+    def test_noop_when_key_already_matches(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        original = "sonar.projectKey=same-key\n"
+        props = tmp_path / "sonar-project.properties"
+        props.write_text(original)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("same-key", "Same Name"):
+            assert props.read_text() == original  # file untouched
+```
+
+- [ ] **Step 2: Run tests to verify they pass (implementation already in file)**
+
+```bash
+uv run pytest tests/sonarqube/test_properties_handler.py::TestPatchContent tests/sonarqube/test_properties_handler.py::TestPatched -v
+```
+
+Expected: all 9 tests PASS.
+
+- [ ] **Step 3: Run the full properties handler test suite**
+
+```bash
+uv run pytest tests/sonarqube/test_properties_handler.py -v
+```
+
+Expected: all 26 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/sonarqube/test_properties_handler.py
+git commit -m "test: add _patch_content and patched context manager tests"
+```
+
+---
+
+## Task 4: Update `AnalysisRunner` to use `SonarPropertiesHandler`
+
+Replaces `_get_scanner_command` with handler delegation. Adds auth hint on failure.
+
+**Files:**
+- Modify: `src/vibe_heal/sonarqube/analysis_runner.py`
+- Modify: `tests/sonarqube/test_analysis_runner.py`
+
+- [ ] **Step 1: Update `analysis_runner.py`**
+
+Replace the entire contents of `src/vibe_heal/sonarqube/analysis_runner.py` with:
+
+```python
+"""SonarQube analysis execution via sonar-scanner CLI."""
+
+import asyncio
+import logging
+import re
+import shutil
+from pathlib import Path
+
+from pydantic import BaseModel
+from rich.console import Console
+
+from vibe_heal.config import VibeHealConfig
+from vibe_heal.sonarqube.client import SonarQubeClient
+from vibe_heal.sonarqube.exceptions import SonarQubeAPIError
+from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler
+
+console = Console()
+logger = logging.getLogger(__name__)
+
+_AUTH_ERROR_RE = re.compile(r"401|403|unauthorized|authentication", re.IGNORECASE)
+_AUTH_HINT = (
+    "\nHint: authentication may be configured via environment variable "
+    "(SONAR_TOKEN, SONARQUBE_TOKEN) or the central scanner settings "
+    "(~/.sonar/sonar-scanner.properties). Check these if you expected "
+    "auth to be picked up automatically."
+)
+
+
+class AnalysisResult(BaseModel):
+    """Result of a SonarQube analysis run."""
+
+    success: bool
+    task_id: str | None = None
+    dashboard_url: str | None = None
+    error_message: str | None = None
+
+
+class AnalysisRunner:
+    """Executes SonarQube analysis using sonar-scanner CLI.
+
+    Runs sonar-scanner as a subprocess and waits for analysis completion
+    on the SonarQube server.
+    """
+
+    def __init__(self, config: VibeHealConfig, client: SonarQubeClient) -> None:
+        self.config = config
+        self.client = client
+
+    async def run_analysis(
+        self,
+        project_key: str,
+        project_name: str,
+        project_dir: Path,
+        sources: list[Path] | None = None,
+    ) -> AnalysisResult:
+        """Run SonarQube analysis on project.
+
+        When sonar-project.properties exists in project_dir, the file governs
+        all scanner configuration. The project key and name are patched in-place
+        before the scanner runs and restored unconditionally afterwards.
+
+        Args:
+            project_key: SonarQube project key
+            project_name: SonarQube project name
+            project_dir: Root directory to analyze
+            sources: Optional list of specific files/dirs (ignored when properties file present)
+
+        Returns:
+            AnalysisResult with success status and details
+        """
+        if not self.validate_scanner_available():
+            return AnalysisResult(
+                success=False,
+                error_message="sonar-scanner is not installed or not in PATH. "
+                "Install from: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner/",
+            )
+
+        handler = SonarPropertiesHandler(project_dir, self.config)
+        command = handler.build_command(project_key, project_name, project_dir, sources)
+
+        with handler.patched(project_key, project_name):
+            try:
+                console.print(f"[dim]    Executing: sonar-scanner (project: {project_key})[/dim]")
+                result = await asyncio.create_subprocess_exec(
+                    *command,
+                    cwd=str(project_dir),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+
+                console.print("[dim]    Waiting for scanner to complete...[/dim]")
+                stdout, stderr = await result.communicate()
+                console.print(f"[dim]    Scanner finished with exit code: {result.returncode}[/dim]")
+
+                if result.returncode != 0:
+                    error_output = stderr.decode() if stderr else stdout.decode()
+                    console.print(f"[red]    Scanner error: {error_output[:500]}[/red]")
+                    error_msg = f"sonar-scanner failed with exit code {result.returncode}: {error_output}"
+                    if handler.exists and _AUTH_ERROR_RE.search(error_output):
+                        error_msg += _AUTH_HINT
+                    return AnalysisResult(success=False, error_message=error_msg)
+
+                scanner_output = stdout.decode()
+                console.print("[dim]    Extracting task ID from scanner output...[/dim]")
+                task_id = self._extract_task_id(scanner_output)
+
+                if not task_id:
+                    console.print("[red]    Could not find task ID in scanner output[/red]")
+                    console.print("[dim]    See debug log for full scanner output[/dim]")
+                    logger.debug("Full scanner output when task ID extraction failed:\n%s", scanner_output)
+                    return AnalysisResult(
+                        success=False,
+                        error_message="Could not extract task ID from scanner output",
+                    )
+
+                console.print(f"[dim]    Task ID: {task_id}[/dim]")
+                console.print("[dim]    Waiting for server-side analysis to complete...[/dim]")
+
+                try:
+                    async with asyncio.timeout(300):
+                        analysis_success = await self._wait_for_analysis(task_id)
+                except TimeoutError:
+                    console.print("[red]    Analysis timed out after 300 seconds[/red]")
+                    return AnalysisResult(
+                        success=False,
+                        task_id=task_id,
+                        error_message="Analysis timed out after 300 seconds",
+                    )
+
+                if not analysis_success:
+                    console.print("[red]    Analysis failed on server[/red]")
+                    return AnalysisResult(
+                        success=False,
+                        task_id=task_id,
+                        error_message="Analysis failed on server",
+                    )
+
+                console.print("[green]    ✓ Server-side analysis completed successfully[/green]")
+                dashboard_url = f"{self.config.sonarqube_url}/dashboard?id={project_key}"
+                return AnalysisResult(success=True, task_id=task_id, dashboard_url=dashboard_url)
+
+            except Exception as e:
+                return AnalysisResult(success=False, error_message=f"Failed to run analysis: {e}")
+
+    async def _wait_for_analysis(self, task_id: str) -> bool:
+        """Poll SonarQube for analysis completion."""
+        poll_interval = 2
+        last_status = None
+
+        while True:
+            try:
+                data = await self.client._request("GET", "/api/ce/task", params={"id": task_id})
+                task = data.get("task", {})
+                status = task.get("status")
+
+                if status != last_status:
+                    console.print(f"[dim]    Analysis status: {status}[/dim]")
+                    last_status = status
+
+                if status == "SUCCESS":
+                    return True
+                if status in ("FAILED", "CANCELED"):
+                    console.print(f"[red]    Analysis failed with status: {status}[/red]")
+                    return False
+
+                await asyncio.sleep(poll_interval)
+
+            except SonarQubeAPIError as e:
+                console.print(f"[yellow]    Warning: API error while polling: {e}[/yellow]")
+                await asyncio.sleep(poll_interval)
+
+    def _extract_task_id(self, scanner_output: str) -> str | None:
+        """Extract task ID from sonar-scanner output."""
+        for line in scanner_output.split("\n"):
+            if "api/ce/task?id=" in line:
+                parts = line.split("api/ce/task?id=")
+                if len(parts) > 1:
+                    return parts[1].split()[0].strip()
+        return None
+
+    def validate_scanner_available(self) -> bool:
+        """Check if sonar-scanner is installed and available."""
+        return shutil.which("sonar-scanner") is not None
+```
+
+- [ ] **Step 2: Update `test_analysis_runner.py` — remove `TestGetScannerCommand`, add auth-hint tests**
+
+Remove the entire `TestGetScannerCommand` class (lines roughly 62–113) from `tests/sonarqube/test_analysis_runner.py` and append these new tests at the end of the file:
+
+```python
+class TestAuthHint:
+    @pytest.mark.asyncio
+    async def test_auth_hint_added_when_properties_file_and_auth_error(
+        self, analysis_runner: AnalysisRunner, tmp_path: Path
+    ) -> None:
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        mock_process = AsyncMock()
+        mock_process.returncode = 1
+        mock_process.communicate = AsyncMock(return_value=(b"", b"ERROR: 401 Unauthorized"))
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="temp-key",
+                project_name="Temp",
+                project_dir=tmp_path,
+            )
+        assert result.success is False
+        assert "SONAR_TOKEN" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_no_auth_hint_without_properties_file(
+        self, analysis_runner: AnalysisRunner, tmp_path: Path
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.returncode = 1
+        mock_process.communicate = AsyncMock(return_value=(b"", b"ERROR: 401 Unauthorized"))
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="test-key",
+                project_name="Test",
+                project_dir=tmp_path,
+            )
+        assert result.success is False
+        assert "SONAR_TOKEN" not in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_no_auth_hint_for_non_auth_failure(
+        self, analysis_runner: AnalysisRunner, tmp_path: Path
+    ) -> None:
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        mock_process = AsyncMock()
+        mock_process.returncode = 1
+        mock_process.communicate = AsyncMock(return_value=(b"", b"ERROR: Project not found"))
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="temp-key",
+                project_name="Temp",
+                project_dir=tmp_path,
+            )
+        assert result.success is False
+        assert "SONAR_TOKEN" not in result.error_message
+```
+
+- [ ] **Step 3: Run the analysis runner tests**
+
+```bash
+uv run pytest tests/sonarqube/test_analysis_runner.py -v
+```
+
+Expected: all tests PASS (the removed `TestGetScannerCommand` tests are now replaced by Task 1's `TestBuildCommandNoFile`).
+
+- [ ] **Step 4: Run full test suite to catch regressions**
+
+```bash
+uv run pytest --tb=short -q
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vibe_heal/sonarqube/analysis_runner.py tests/sonarqube/test_analysis_runner.py
+git commit -m "feat: use SonarPropertiesHandler in AnalysisRunner, add auth hint"
+```
+
+---
+
+## Task 5: Update `ProjectManager` with `command_name` and human-readable name
+
+**Files:**
+- Modify: `src/vibe_heal/sonarqube/project_manager.py`
+- Modify: `tests/sonarqube/test_project_manager.py`
+
+- [ ] **Step 1: Write failing tests**
+
+In `tests/sonarqube/test_project_manager.py`, add a new test class for name format and update the `test_create_temp_project_success` assertion. Replace the `assert metadata.project_name == metadata.project_key` line with name format assertions, and add a dedicated test class:
+
+Find the line:
+```python
+        assert metadata.project_name == metadata.project_key
+```
+
+Replace it with:
+```python
+        assert metadata.project_name == "my_project analysis user feature-new-api"
+```
+
+Then append this new test class at the end of the `TestCreateTempProject` class:
+
+```python
+    @pytest.mark.asyncio
+    async def test_project_name_format_with_command(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="my-project",
+            branch_name="feature/add-login",
+            user_email="alexei.eleusis@gmail.com",
+            command_name="review",
+        )
+        assert metadata.project_name == "my-project review alexei.eleusis feature-add-login"
+
+    @pytest.mark.asyncio
+    async def test_project_name_uses_default_command_name(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="my-project",
+            branch_name="main",
+            user_email="user@example.com",
+        )
+        assert metadata.project_name == "my-project analysis user main"
+
+    @pytest.mark.asyncio
+    async def test_project_name_email_without_at_sign(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="proj",
+            branch_name="main",
+            user_email="localonly",
+            command_name="cleanup",
+        )
+        assert metadata.project_name == "proj cleanup localonly main"
+
+    @pytest.mark.asyncio
+    async def test_project_name_branch_slashes_become_dashes(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="proj",
+            branch_name="feature/nested/branch",
+            user_email="u@t.com",
+            command_name="dedupe-branch",
+        )
+        assert metadata.project_name == "proj dedupe-branch u feature-nested-branch"
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/sonarqube/test_project_manager.py::TestCreateTempProject -v
+```
+
+Expected: `test_create_temp_project_success` FAILS (assertion mismatch on `project_name`), new tests FAIL (unexpected keyword argument `command_name`).
+
+- [ ] **Step 3: Update `project_manager.py`**
+
+In `src/vibe_heal/sonarqube/project_manager.py`, update `create_temp_project`:
+
+Replace:
+```python
+    async def create_temp_project(
+        self,
+        base_key: str,
+        branch_name: str,
+        user_email: str,
+    ) -> TempProjectMetadata:
+        """Create temporary project for branch analysis.
+
+        Project key/name format: {base_key}_{sanitized_email}_{sanitized_branch}_{timestamp}
+        Timestamp format: yymmdd-hhmm
+        Sanitization: replace non-alphanumeric with underscore, lowercase.
+
+        Args:
+            base_key: Base project key (from .env.vibeheal)
+            branch_name: Current branch name
+            user_email: Git user email
+
+        Returns:
+            Metadata for the created project (for later cleanup)
+
+        Raises:
+            SonarQubeAPIError: If project creation fails
+        """
+        # Sanitize components
+        sanitized_email = self._sanitize_identifier(user_email)
+        sanitized_branch = self._sanitize_identifier(branch_name)
+
+        # Generate timestamp in yymmdd-hhmm format
+        timestamp = datetime.now(timezone.utc).strftime("%y%m%d-%H%M")
+
+        # Build project key and name
+        project_key = f"{base_key}_{sanitized_email}_{sanitized_branch}_{timestamp}"
+        project_name = project_key  # Use same value for both
+
+        # Create project via API
+        await self.client.create_project(project_key, project_name)
+
+        # Build metadata
+        metadata = TempProjectMetadata(
+            project_key=project_key,
+            project_name=project_name,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            base_project_key=base_key,
+            branch_name=branch_name,
+            user_email=user_email,
+        )
+
+        return metadata
+```
+
+With:
+```python
+    async def create_temp_project(
+        self,
+        base_key: str,
+        branch_name: str,
+        user_email: str,
+        command_name: str = "analysis",
+    ) -> TempProjectMetadata:
+        """Create temporary project for branch analysis.
+
+        Project key format: {base_key}_{sanitized_email}_{sanitized_branch}_{timestamp}
+        Project name format: {base_key} {command_name} {email_local_part} {branch_with_dashes}
+        Timestamp format: yymmdd-hhmm
+
+        Args:
+            base_key: Base project key (from .env.vibeheal)
+            branch_name: Current branch name
+            user_email: Git user email
+            command_name: Name of the vibe-heal command (e.g. "review", "cleanup")
+
+        Returns:
+            Metadata for the created project (for later cleanup)
+
+        Raises:
+            SonarQubeAPIError: If project creation fails
+        """
+        sanitized_email = self._sanitize_identifier(user_email)
+        sanitized_branch = self._sanitize_identifier(branch_name)
+        timestamp = datetime.now(timezone.utc).strftime("%y%m%d-%H%M")
+        project_key = f"{base_key}_{sanitized_email}_{sanitized_branch}_{timestamp}"
+
+        email_local = user_email.split("@")[0] if "@" in user_email else user_email
+        branch_display = branch_name.replace("/", "-")
+        project_name = f"{base_key} {command_name} {email_local} {branch_display}"
+
+        await self.client.create_project(project_key, project_name)
+
+        return TempProjectMetadata(
+            project_key=project_key,
+            project_name=project_name,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            base_project_key=base_key,
+            branch_name=branch_name,
+            user_email=user_email,
+        )
+```
+
+Also update `create_temp_project_with_settings` to accept and forward `command_name`:
+
+Replace:
+```python
+    async def create_temp_project_with_settings(
+        self,
+        base_key: str,
+        branch_name: str,
+        user_email: str,
+        console: Console,
+    ) -> TempProjectMetadata:
+        """Create temporary project and copy exclusion settings from source.
+
+        Combines temp project creation with exclusion settings copy into a
+        single operation, used by both cleanup and deduplication workflows.
+
+        Args:
+            base_key: Base project key (source project to copy settings from)
+            branch_name: Current branch name
+            user_email: Git user email
+            console: Rich console for progress output
+
+        Returns:
+            Metadata for the created project
+        """
+        console.print("\n[dim]Creating temporary SonarQube project...[/dim]")
+        temp_project = await self.create_temp_project(
+            base_key=base_key,
+            branch_name=branch_name,
+            user_email=user_email,
+        )
+```
+
+With:
+```python
+    async def create_temp_project_with_settings(
+        self,
+        base_key: str,
+        branch_name: str,
+        user_email: str,
+        console: Console,
+        command_name: str = "analysis",
+    ) -> TempProjectMetadata:
+        """Create temporary project and copy exclusion settings from source.
+
+        Combines temp project creation with exclusion settings copy into a
+        single operation, used by both cleanup and deduplication workflows.
+
+        Args:
+            base_key: Base project key (source project to copy settings from)
+            branch_name: Current branch name
+            user_email: Git user email
+            console: Rich console for progress output
+            command_name: Name of the vibe-heal command (e.g. "cleanup", "dedupe-branch")
+
+        Returns:
+            Metadata for the created project
+        """
+        console.print("\n[dim]Creating temporary SonarQube project...[/dim]")
+        temp_project = await self.create_temp_project(
+            base_key=base_key,
+            branch_name=branch_name,
+            user_email=user_email,
+            command_name=command_name,
+        )
+```
+
+- [ ] **Step 4: Run the project manager tests**
+
+```bash
+uv run pytest tests/sonarqube/test_project_manager.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vibe_heal/sonarqube/project_manager.py tests/sonarqube/test_project_manager.py
+git commit -m "feat: add command_name param and human-readable project name to create_temp_project"
+```
+
+---
+
+## Task 6: Update orchestrators to pass `command_name`
+
+Three orchestrators each have a `_create_temp_project` method that calls either `create_temp_project` or `create_temp_project_with_settings`.
+
+**Files:**
+- Modify: `src/vibe_heal/review/orchestrator.py`
+- Modify: `src/vibe_heal/cleanup/orchestrator.py`
+- Modify: `src/vibe_heal/deduplication/orchestrator.py`
+
+- [ ] **Step 1: Update `ReviewOrchestrator._create_temp_project`**
+
+In `src/vibe_heal/review/orchestrator.py`, find `_create_temp_project` (around line 295). Update the `create_temp_project` call:
+
+Replace:
+```python
+        temp_project = await self.project_manager.create_temp_project(
+            base_key=self.config.sonarqube_project_key,
+            branch_name=current_branch,
+            user_email=user_email,
+        )
+```
+
+With:
+```python
+        temp_project = await self.project_manager.create_temp_project(
+            base_key=self.config.sonarqube_project_key,
+            branch_name=current_branch,
+            user_email=user_email,
+            command_name="review",
+        )
+```
+
+- [ ] **Step 2: Update `CleanupOrchestrator._create_temp_project`**
+
+In `src/vibe_heal/cleanup/orchestrator.py`, find `_create_temp_project` (around line 225). Update the `create_temp_project_with_settings` call:
+
+Replace:
+```python
+        return await self.project_manager.create_temp_project_with_settings(
+            base_key=self.config.sonarqube_project_key,
+            branch_name=current_branch,
+            user_email=user_email,
+            console=console,
+        )
+```
+
+With:
+```python
+        return await self.project_manager.create_temp_project_with_settings(
+            base_key=self.config.sonarqube_project_key,
+            branch_name=current_branch,
+            user_email=user_email,
+            console=console,
+            command_name="cleanup",
+        )
+```
+
+- [ ] **Step 3: Update `DedupeBranchOrchestrator._create_temp_project`**
+
+In `src/vibe_heal/deduplication/orchestrator.py`, find `_create_temp_project` (around line 695). Update the `create_temp_project_with_settings` call:
+
+Replace:
+```python
+        return await self.project_manager.create_temp_project_with_settings(
+            base_key=self.config.sonarqube_project_key,
+            branch_name=branch_name,
+            user_email=user_email,
+            console=self.console,
+        )
+```
+
+With:
+```python
+        return await self.project_manager.create_temp_project_with_settings(
+            base_key=self.config.sonarqube_project_key,
+            branch_name=branch_name,
+            user_email=user_email,
+            console=self.console,
+            command_name="dedupe-branch",
+        )
+```
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+uv run pytest --tb=short -q
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run type checking**
+
+```bash
+uv run mypy
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/vibe_heal/review/orchestrator.py src/vibe_heal/cleanup/orchestrator.py src/vibe_heal/deduplication/orchestrator.py
+git commit -m "feat: pass command_name to create_temp_project in all orchestrators"
+```

--- a/docs/superpowers/specs/2026-05-21-sonar-properties-file-design.md
+++ b/docs/superpowers/specs/2026-05-21-sonar-properties-file-design.md
@@ -1,0 +1,145 @@
+# sonar-project.properties Integration
+
+**Date:** 2026-05-21
+**Status:** Approved
+
+## Problem
+
+When `sonar-project.properties` exists in the project directory, vibe-heal ignores it entirely and builds a full sonar-scanner command with explicit `-D` flags. This causes two problems:
+
+1. Configuration values only in the file (custom exclusions, source encoding, analysis scope, language-specific settings) are silently dropped when vibe-heal runs the scanner.
+2. When creating a temporary project (review, cleanup, dedupe-branch), the file's `sonar.projectKey` still points at the original project, so the analysis lands in the wrong project.
+
+## Solution Overview
+
+Introduce `SonarPropertiesHandler` — a new class that detects the properties file, builds a minimal scanner command when the file is present, and patches the file's project key/name before scanner invocation (restoring it unconditionally in a `finally` block).
+
+Applies to all commands that run sonar-scanner: `review`, `cleanup`, `dedupe-branch`.
+
+---
+
+## New Component: `SonarPropertiesHandler`
+
+**Location:** `src/vibe_heal/sonarqube/properties_handler.py`
+
+### Command building
+
+`build_command(project_key, project_name, sources) -> list[str]`
+
+- **No properties file present** → returns the existing full `-D` flag command (identical to today, no regression).
+- **Properties file present** → returns `["sonar-scanner"]` plus an auth token only as a fallback (see Auth section). Project key, project name, host URL, and sources are all omitted from the command — the file governs them.
+
+### File patching
+
+`patched(project_key, project_name)` — a `contextlib.contextmanager`.
+
+- **On enter:** reads the original file content, detects existing `sonar.projectKey` and `sonar.projectName` lines, comments them out with a recovery header, and inserts the new values above them.
+- **On exit (`finally`):** writes the original content back unconditionally.
+- **No-op** if the file does not exist, or if the requested `project_key` already matches the `sonar.projectKey` value in the file (key comparison only; name is always updated when key changes).
+
+Patch format:
+```
+# vibe-heal: temporary analysis project. If this process was interrupted,
+# restore the lines below (remove the '#' prefix):
+# sonar.projectKey=my-original-project
+# sonar.projectName=My Original Project
+sonar.projectKey=my-project_user_feature_branch_260521-1430
+sonar.projectName=my-project review alexei.eleusis feature-add-login
+```
+
+If `sonar.projectName` is not present in the original file, no comment is added for it — the new name line is appended without a paired comment.
+
+### Restore safety net
+
+If the `finally` write-back itself fails (e.g. disk full), the handler logs the original file content at `ERROR` level so the user can manually restore it. It never raises from the restore path so the outer `finally` (temp project deletion) always runs.
+
+---
+
+## Changes to `AnalysisRunner`
+
+`run_analysis()` creates a `SonarPropertiesHandler` scoped to `project_dir` and wraps the scanner invocation:
+
+```python
+handler = SonarPropertiesHandler(project_dir, config)
+with handler.patched(project_key, project_name):
+    command = handler.build_command(project_key, project_name, sources)
+    # run sonar-scanner subprocess (unchanged)
+```
+
+When the properties file is present and the scanner exits non-zero, `run_analysis()` inspects the combined stdout/stderr for auth-related keywords (`401`, `403`, `Unauthorized`, `Authentication`, case-insensitive). If found, it appends to the error message:
+
+> Hint: authentication may be configured via environment variable (SONAR_TOKEN, SONARQUBE_TOKEN) or the central scanner settings (~/.sonar/sonar-scanner.properties). Check these if you expected auth to be picked up automatically.
+
+---
+
+## Auth Detection
+
+`SonarPropertiesHandler._has_auth_configured() -> bool` checks in order:
+
+1. **Environment variables:** `SONAR_TOKEN`, `SONARQUBE_TOKEN`, `SONAR_LOGIN` — any non-empty value means auth is covered.
+2. **Properties file:** scans for non-commented lines matching `sonar.token=`, `sonar.login=`, or `sonar.password=` — any found means auth is covered.
+
+If neither check passes, `build_command` appends the auth flags from config as a fallback (token auth: `-Dsonar.token=…`; basic auth: `-Dsonar.login=…` + `-Dsonar.password=…`).
+
+---
+
+## Changes to `ProjectManager`
+
+`create_temp_project()` gains a `command_name: str` parameter (e.g. `"review"`, `"cleanup"`, `"dedupe-branch"`).
+
+The project **name** (display name in SonarQube UI) is now generated as:
+
+```
+{base_key} {command_name} {email_local_part} {branch_with_slashes_as_dashes}
+```
+
+Examples:
+- `"my-project review alexei.eleusis feature-add-login"`
+- `"my-project cleanup alexei.eleusis main"`
+
+The email local part is the portion before `@`. Branch slashes become dashes. The project **key** is unchanged (sanitized alphanumeric, no spaces).
+
+Each calling orchestrator (`ReviewOrchestrator`, `CleanupOrchestrator`, `DedupeBranchOrchestrator`) passes its own command name string.
+
+---
+
+## Data Flow
+
+```
+Orchestrator.run_analysis()
+  └─ _create_temp_project(command_name="review")      ← new param
+       └─ ProjectManager.create_temp_project(...)      ← name format changed
+  └─ AnalysisRunner.run_analysis(project_key, ...)
+       └─ SonarPropertiesHandler(project_dir, config)  ← new
+            ├─ patched(project_key, project_name)       ← patches file in-place
+            └─ build_command(...)                       ← minimal or full command
+```
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Properties file absent | Full `-D` command, identical to today |
+| Properties file present, auth in env/file | Minimal command, no auth flag injected |
+| Properties file present, no auth anywhere | Minimal command + auth flag from config |
+| Scanner auth failure + properties file present | Error message + auth hint |
+| Restore write-back fails | Log original content at ERROR, continue cleanup |
+| Two concurrent vibe-heal runs on same repo | Last writer wins on restore; acceptable edge case |
+
+---
+
+## Testing
+
+- `SonarPropertiesHandler.exists` — with and without file present
+- `build_command` — file absent (full command), file present (minimal command), auth fallback injected vs. skipped
+- `patched` context manager:
+  - File content is patched during `with` block
+  - Original restored after normal exit
+  - Original restored after exception inside block
+  - No-op when file absent
+  - No-op when `project_key` already matches file's `sonar.projectKey`
+- `_has_auth_configured` — env var present, file property present, neither present, commented-out line in file (must not count)
+- Auth failure hint — appended when properties file present and output contains auth keywords; not appended otherwise
+- `ProjectManager.create_temp_project` — name includes command, email local part, branch with `/` → `-`

--- a/src/vibe_heal/ai_tools/__init__.py
+++ b/src/vibe_heal/ai_tools/__init__.py
@@ -1,5 +1,7 @@
 """AI tool integration for vibe-heal."""
 
+from typing import Any
+
 from vibe_heal.ai_tools.aider import AiderTool
 from vibe_heal.ai_tools.base import AITool, AIToolType
 from vibe_heal.ai_tools.claude_code import ClaudeCodeTool
@@ -21,7 +23,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """Lazy import of create_fix_prompt to avoid circular imports."""
     if name == "create_fix_prompt":
         from vibe_heal.ai_tools.prompts import create_fix_prompt as _create_fix_prompt

--- a/src/vibe_heal/ai_tools/__init__.py
+++ b/src/vibe_heal/ai_tools/__init__.py
@@ -7,7 +7,6 @@ from vibe_heal.ai_tools.factory import AIToolFactory
 from vibe_heal.ai_tools.gemini import GeminiCliTool
 from vibe_heal.ai_tools.models import FixResult
 from vibe_heal.ai_tools.opencode import OpenCodeTool
-from vibe_heal.ai_tools.prompts import create_fix_prompt
 
 __all__ = [
     "AITool",
@@ -20,3 +19,12 @@ __all__ = [
     "OpenCodeTool",
     "create_fix_prompt",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy import of create_fix_prompt to avoid circular imports."""
+    if name == "create_fix_prompt":
+        from vibe_heal.ai_tools.prompts import create_fix_prompt as _create_fix_prompt
+
+        return _create_fix_prompt
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/vibe_heal/cleanup/orchestrator.py
+++ b/src/vibe_heal/cleanup/orchestrator.py
@@ -236,6 +236,7 @@ class CleanupOrchestrator:
             branch_name=current_branch,
             user_email=user_email,
             console=console,
+            command_name="cleanup",
         )
 
     async def _check_files_for_issues(

--- a/src/vibe_heal/deduplication/orchestrator.py
+++ b/src/vibe_heal/deduplication/orchestrator.py
@@ -706,6 +706,7 @@ class DedupeBranchOrchestrator:
             branch_name=branch_name,
             user_email=user_email,
             console=self.console,
+            command_name="dedupe-branch",
         )
 
     async def _cleanup_temp_project(self, temp_project: "TempProjectMetadata") -> None:

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -306,6 +306,7 @@ class ReviewOrchestrator:
             base_key=self.config.sonarqube_project_key,
             branch_name=current_branch,
             user_email=user_email,
+            command_name="review",
         )
         console.print(f"[dim]Created project: {temp_project.project_key}[/dim]")
 

--- a/src/vibe_heal/sonarqube/analysis_runner.py
+++ b/src/vibe_heal/sonarqube/analysis_runner.py
@@ -102,14 +102,9 @@ class AnalysisRunner:
                 if result.returncode != 0:
                     stdout_text = stdout.decode() if stdout else ""
                     stderr_text = stderr.decode() if stderr else ""
-                    combined_error_output = "\n".join(
-                        output for output in (stderr_text, stdout_text) if output
-                    )
+                    combined_error_output = "\n".join(output for output in (stderr_text, stdout_text) if output)
                     console.print(f"[red]    Scanner error: {combined_error_output[:500]}[/red]")
-                    error_msg = (
-                        f"sonar-scanner failed with exit code {result.returncode}: "
-                        f"{combined_error_output}"
-                    )
+                    error_msg = f"sonar-scanner failed with exit code {result.returncode}: {combined_error_output}"
                     if handler.exists and _AUTH_ERROR_RE.search(combined_error_output):
                         error_msg += _AUTH_HINT
                     return AnalysisResult(

--- a/src/vibe_heal/sonarqube/analysis_runner.py
+++ b/src/vibe_heal/sonarqube/analysis_runner.py
@@ -100,10 +100,17 @@ class AnalysisRunner:
                 console.print(f"[dim]    Scanner finished with exit code: {result.returncode}[/dim]")
 
                 if result.returncode != 0:
-                    error_output = stderr.decode() if stderr else stdout.decode()
-                    console.print(f"[red]    Scanner error: {error_output[:500]}[/red]")
-                    error_msg = f"sonar-scanner failed with exit code {result.returncode}: {error_output}"
-                    if handler.exists and _AUTH_ERROR_RE.search(error_output):
+                    stdout_text = stdout.decode() if stdout else ""
+                    stderr_text = stderr.decode() if stderr else ""
+                    combined_error_output = "\n".join(
+                        output for output in (stderr_text, stdout_text) if output
+                    )
+                    console.print(f"[red]    Scanner error: {combined_error_output[:500]}[/red]")
+                    error_msg = (
+                        f"sonar-scanner failed with exit code {result.returncode}: "
+                        f"{combined_error_output}"
+                    )
+                    if handler.exists and _AUTH_ERROR_RE.search(combined_error_output):
                         error_msg += _AUTH_HINT
                     return AnalysisResult(
                         success=False,

--- a/src/vibe_heal/sonarqube/analysis_runner.py
+++ b/src/vibe_heal/sonarqube/analysis_runner.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 import shutil
 from pathlib import Path
 
@@ -11,9 +12,18 @@ from rich.console import Console
 from vibe_heal.config import VibeHealConfig
 from vibe_heal.sonarqube.client import SonarQubeClient
 from vibe_heal.sonarqube.exceptions import SonarQubeAPIError
+from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler
 
 console = Console()
 logger = logging.getLogger(__name__)
+
+_AUTH_ERROR_RE = re.compile(r"401|403|unauthorized|authentication", re.IGNORECASE)
+_AUTH_HINT = (
+    "\nHint: authentication may be configured via environment variable "
+    "(SONAR_TOKEN, SONARQUBE_TOKEN) or the central scanner settings "
+    "(~/.sonar/sonar-scanner.properties). Check these if you expected "
+    "auth to be picked up automatically."
+)
 
 
 class AnalysisResult(BaseModel):
@@ -71,133 +81,89 @@ class AnalysisRunner:
                 "Install from: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner/",
             )
 
-        # Build scanner command
-        command = self._get_scanner_command(
-            project_key=project_key,
-            project_name=project_name,
-            project_dir=project_dir,
-            sources=sources,
-        )
+        handler = SonarPropertiesHandler(project_dir, self.config)
+        command = handler.build_command(project_key, project_name, sources)
 
         # Execute scanner
-        try:
-            console.print(f"[dim]    Executing: sonar-scanner (project: {project_key})[/dim]")
-            result = await asyncio.create_subprocess_exec(
-                *command,
-                cwd=str(project_dir),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-
-            console.print("[dim]    Waiting for scanner to complete...[/dim]")
-            stdout, stderr = await result.communicate()
-            console.print(f"[dim]    Scanner finished with exit code: {result.returncode}[/dim]")
-
-            if result.returncode != 0:
-                error_output = stderr.decode() if stderr else stdout.decode()
-                console.print(f"[red]    Scanner error: {error_output[:500]}[/red]")
-                return AnalysisResult(
-                    success=False,
-                    error_message=f"sonar-scanner failed with exit code {result.returncode}: {error_output}",
-                )
-
-            # Extract task ID from scanner output
-            scanner_output = stdout.decode()
-            console.print("[dim]    Extracting task ID from scanner output...[/dim]")
-            task_id = self._extract_task_id(scanner_output)
-
-            if not task_id:
-                console.print("[red]    Could not find task ID in scanner output[/red]")
-                console.print("[dim]    See debug log for full scanner output[/dim]")
-                # Log full scanner output to debug log for troubleshooting
-                logger.debug("Full scanner output when task ID extraction failed:\n%s", scanner_output)
-                return AnalysisResult(
-                    success=False,
-                    error_message="Could not extract task ID from scanner output",
-                )
-
-            console.print(f"[dim]    Task ID: {task_id}[/dim]")
-
-            # Wait for analysis to complete on server
-            console.print("[dim]    Waiting for server-side analysis to complete...[/dim]")
+        with handler.patched(project_key, project_name):
             try:
-                async with asyncio.timeout(300):
-                    analysis_success = await self._wait_for_analysis(task_id)
-            except TimeoutError:
-                console.print("[red]    Analysis timed out after 300 seconds[/red]")
-                return AnalysisResult(
-                    success=False,
-                    task_id=task_id,
-                    error_message="Analysis timed out after 300 seconds",
+                console.print(f"[dim]    Executing: sonar-scanner (project: {project_key})[/dim]")
+                result = await asyncio.create_subprocess_exec(
+                    *command,
+                    cwd=str(project_dir),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
                 )
 
-            if not analysis_success:
-                console.print("[red]    Analysis failed on server[/red]")
+                console.print("[dim]    Waiting for scanner to complete...[/dim]")
+                stdout, stderr = await result.communicate()
+                console.print(f"[dim]    Scanner finished with exit code: {result.returncode}[/dim]")
+
+                if result.returncode != 0:
+                    error_output = stderr.decode() if stderr else stdout.decode()
+                    console.print(f"[red]    Scanner error: {error_output[:500]}[/red]")
+                    error_msg = f"sonar-scanner failed with exit code {result.returncode}: {error_output}"
+                    if handler.exists and _AUTH_ERROR_RE.search(error_output):
+                        error_msg += _AUTH_HINT
+                    return AnalysisResult(
+                        success=False,
+                        error_message=error_msg,
+                    )
+
+                # Extract task ID from scanner output
+                scanner_output = stdout.decode()
+                console.print("[dim]    Extracting task ID from scanner output...[/dim]")
+                task_id = self._extract_task_id(scanner_output)
+
+                if not task_id:
+                    console.print("[red]    Could not find task ID in scanner output[/red]")
+                    console.print("[dim]    See debug log for full scanner output[/dim]")
+                    # Log full scanner output to debug log for troubleshooting
+                    logger.debug("Full scanner output when task ID extraction failed:\n%s", scanner_output)
+                    return AnalysisResult(
+                        success=False,
+                        error_message="Could not extract task ID from scanner output",
+                    )
+
+                console.print(f"[dim]    Task ID: {task_id}[/dim]")
+
+                # Wait for analysis to complete on server
+                console.print("[dim]    Waiting for server-side analysis to complete...[/dim]")
+                try:
+                    async with asyncio.timeout(300):
+                        analysis_success = await self._wait_for_analysis(task_id)
+                except TimeoutError:
+                    console.print("[red]    Analysis timed out after 300 seconds[/red]")
+                    return AnalysisResult(
+                        success=False,
+                        task_id=task_id,
+                        error_message="Analysis timed out after 300 seconds",
+                    )
+
+                if not analysis_success:
+                    console.print("[red]    Analysis failed on server[/red]")
+                    return AnalysisResult(
+                        success=False,
+                        task_id=task_id,
+                        error_message="Analysis failed on server",
+                    )
+
+                console.print("[green]    ✓ Server-side analysis completed successfully[/green]")
+
+                # Build dashboard URL
+                dashboard_url = f"{self.config.sonarqube_url}/dashboard?id={project_key}"
+
                 return AnalysisResult(
-                    success=False,
+                    success=True,
                     task_id=task_id,
-                    error_message="Analysis failed on server",
+                    dashboard_url=dashboard_url,
                 )
 
-            console.print("[green]    ✓ Server-side analysis completed successfully[/green]")
-
-            # Build dashboard URL
-            dashboard_url = f"{self.config.sonarqube_url}/dashboard?id={project_key}"
-
-            return AnalysisResult(
-                success=True,
-                task_id=task_id,
-                dashboard_url=dashboard_url,
-            )
-
-        except Exception as e:
-            return AnalysisResult(
-                success=False,
-                error_message=f"Failed to run analysis: {e}",
-            )
-
-    def _get_scanner_command(
-        self,
-        project_key: str,
-        project_name: str,
-        project_dir: Path,
-        sources: list[Path] | None = None,
-    ) -> list[str]:
-        """Build sonar-scanner command with parameters.
-
-        Args:
-            project_key: SonarQube project key
-            project_name: SonarQube project name
-            project_dir: Root directory to analyze
-            sources: Optional list of specific files/dirs to analyze
-
-        Returns:
-            Command list ready for subprocess execution
-        """
-        command = [
-            "sonar-scanner",
-            f"-Dsonar.projectKey={project_key}",
-            f"-Dsonar.projectName={project_name}",
-            f"-Dsonar.host.url={self.config.sonarqube_url}",
-        ]
-
-        # Add authentication
-        if self.config.use_token_auth:
-            command.append(f"-Dsonar.token={self.config.sonarqube_token}")
-        else:
-            command.append(f"-Dsonar.login={self.config.sonarqube_username}")
-            command.append(f"-Dsonar.password={self.config.sonarqube_password}")
-
-        # Add sources if specified (optimization for partial analysis)
-        if sources:
-            # Convert Paths to strings, relative to project_dir
-            sources_str = ",".join(str(s) for s in sources)
-            command.append(f"-Dsonar.sources={sources_str}")
-        else:
-            # Default to current directory
-            command.append("-Dsonar.sources=.")
-
-        return command
+            except Exception as e:
+                return AnalysisResult(
+                    success=False,
+                    error_message=f"Failed to run analysis: {e}",
+                )
 
     async def _wait_for_analysis(self, task_id: str) -> bool:
         """Poll SonarQube for analysis completion.

--- a/src/vibe_heal/sonarqube/project_manager.py
+++ b/src/vibe_heal/sonarqube/project_manager.py
@@ -54,10 +54,12 @@ class ProjectManager:
         base_key: str,
         branch_name: str,
         user_email: str,
+        command_name: str = "analysis",
     ) -> TempProjectMetadata:
         """Create temporary project for branch analysis.
 
-        Project key/name format: {base_key}_{sanitized_email}_{sanitized_branch}_{timestamp}
+        Project key format: {base_key}_{sanitized_email}_{sanitized_branch}_{timestamp}
+        Project name format: {base_key} {command_name} {email_local_part} {branch_with_dashes}
         Timestamp format: yymmdd-hhmm
         Sanitization: replace non-alphanumeric with underscore, lowercase.
 
@@ -65,6 +67,7 @@ class ProjectManager:
             base_key: Base project key (from .env.vibeheal)
             branch_name: Current branch name
             user_email: Git user email
+            command_name: Name of the command creating the project (e.g. "cleanup", "review")
 
         Returns:
             Metadata for the created project (for later cleanup)
@@ -79,9 +82,10 @@ class ProjectManager:
         # Generate timestamp in yymmdd-hhmm format
         timestamp = datetime.now(timezone.utc).strftime("%y%m%d-%H%M")
 
-        # Build project key and name
         project_key = f"{base_key}_{sanitized_email}_{sanitized_branch}_{timestamp}"
-        project_name = project_key  # Use same value for both
+        email_local = user_email.split("@")[0] if "@" in user_email else user_email
+        branch_display = branch_name.replace("/", "-")
+        project_name = f"{base_key} {command_name} {email_local} {branch_display}"
 
         # Create project via API
         await self.client.create_project(project_key, project_name)
@@ -199,6 +203,7 @@ class ProjectManager:
         branch_name: str,
         user_email: str,
         console: Console,
+        command_name: str = "analysis",
     ) -> TempProjectMetadata:
         """Create temporary project and copy exclusion settings from source.
 
@@ -210,6 +215,7 @@ class ProjectManager:
             branch_name: Current branch name
             user_email: Git user email
             console: Rich console for progress output
+            command_name: Name of the command creating the project (e.g. "cleanup", "review")
 
         Returns:
             Metadata for the created project
@@ -219,6 +225,7 @@ class ProjectManager:
             base_key=base_key,
             branch_name=branch_name,
             user_email=user_email,
+            command_name=command_name,
         )
         console.print(f"[dim]Created project: {temp_project.project_key}[/dim]")
 

--- a/src/vibe_heal/sonarqube/properties_handler.py
+++ b/src/vibe_heal/sonarqube/properties_handler.py
@@ -35,11 +35,10 @@ class SonarPropertiesHandler:
         self,
         project_key: str,
         project_name: str,
-        project_dir: Path,
         sources: list[Path] | None = None,
     ) -> list[str]:
         if not self.exists:
-            return self._build_full_command(project_key, project_name, project_dir, sources)
+            return self._build_full_command(project_key, project_name, sources)
         command = ["sonar-scanner"]
         if not self._has_auth_configured():
             if self.config.use_token_auth:
@@ -53,7 +52,6 @@ class SonarPropertiesHandler:
         self,
         project_key: str,
         project_name: str,
-        project_dir: Path,
         sources: list[Path] | None = None,
     ) -> list[str]:
         command = [

--- a/src/vibe_heal/sonarqube/properties_handler.py
+++ b/src/vibe_heal/sonarqube/properties_handler.py
@@ -141,22 +141,26 @@ def _redact_auth_properties(content: str) -> str:
 
 def _find_key_name_indices(
     lines: list[str],
-) -> tuple[int | None, int | None, str | None, str | None]:
-    """Return (key_idx, name_idx, orig_key_line, orig_name_line) from a properties file."""
-    key_idx: int | None = None
-    name_idx: int | None = None
+) -> tuple[list[int], list[int], str | None, str | None]:
+    """Return (key_indices, name_indices, orig_key_line, orig_name_line) from a properties file.
+
+    Collects ALL non-commented occurrences so duplicates don't survive patching
+    and override the temporary values (Java properties files use last-wins semantics).
+    """
+    key_indices: list[int] = []
+    name_indices: list[int] = []
     orig_key_line: str | None = None
     orig_name_line: str | None = None
     for i, line in enumerate(lines):
         if line.lstrip().startswith("#"):
             continue
-        if _KEY_RE.match(line) and key_idx is None:
-            key_idx = i
+        if _KEY_RE.match(line):
+            key_indices.append(i)
             orig_key_line = line.rstrip("\n").rstrip("\r")
-        elif _NAME_RE.match(line) and name_idx is None:
-            name_idx = i
+        elif _NAME_RE.match(line):
+            name_indices.append(i)
             orig_name_line = line.rstrip("\n").rstrip("\r")
-    return key_idx, name_idx, orig_key_line, orig_name_line
+    return key_indices, name_indices, orig_key_line, orig_name_line
 
 
 def _build_recovery_block(
@@ -178,16 +182,16 @@ def _build_recovery_block(
 
 def _patch_content(content: str, new_key: str, new_name: str) -> str:
     lines = content.splitlines(keepends=True)
-    key_idx, name_idx, orig_key_line, orig_name_line = _find_key_name_indices(lines)
+    key_indices, name_indices, orig_key_line, orig_name_line = _find_key_name_indices(lines)
 
     recovery = _build_recovery_block(orig_key_line, orig_name_line, new_key, new_name)
 
-    present = [i for i in (key_idx, name_idx) if i is not None]
-    if not present:
+    all_indices = key_indices + name_indices
+    if not all_indices:
         return content + f"sonar.projectKey={new_key}\n" + f"sonar.projectName={new_name}\n"
 
-    first_idx = min(present)
-    skip = set(present)
+    first_idx = min(all_indices)
+    skip = set(all_indices)
     result: list[str] = []
     for i, line in enumerate(lines):
         if i == first_idx:

--- a/src/vibe_heal/sonarqube/properties_handler.py
+++ b/src/vibe_heal/sonarqube/properties_handler.py
@@ -32,7 +32,7 @@ class SonarPropertiesHandler:
 
     @property
     def exists(self) -> bool:
-        return self.properties_file.exists()
+        return self.properties_file.is_file()
 
     def build_command(
         self,

--- a/src/vibe_heal/sonarqube/properties_handler.py
+++ b/src/vibe_heal/sonarqube/properties_handler.py
@@ -1,0 +1,179 @@
+"""sonar-project.properties detection, command building, and file patching."""
+
+import logging
+import os
+import re
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+from vibe_heal.config import VibeHealConfig
+
+logger = logging.getLogger(__name__)
+
+PROPERTIES_FILENAME = "sonar-project.properties"
+
+_KEY_RE = re.compile(r"^\s*sonar\.projectKey\s*=", re.IGNORECASE)
+_NAME_RE = re.compile(r"^\s*sonar\.projectName\s*=", re.IGNORECASE)
+_AUTH_PROPS_RE = re.compile(r"^\s*sonar\.(token|login|password)\s*=\s*.+", re.IGNORECASE)
+_AUTH_ENV_VARS = ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN")
+
+
+class SonarPropertiesHandler:
+    """Detects sonar-project.properties, builds scanner commands, and patches the file for temp projects."""
+
+    def __init__(self, project_dir: Path, config: VibeHealConfig) -> None:
+        self.project_dir = project_dir
+        self.config = config
+        self.properties_file = project_dir / PROPERTIES_FILENAME
+
+    @property
+    def exists(self) -> bool:
+        return self.properties_file.exists()
+
+    def build_command(
+        self,
+        project_key: str,
+        project_name: str,
+        project_dir: Path,
+        sources: list[Path] | None = None,
+    ) -> list[str]:
+        if not self.exists:
+            return self._build_full_command(project_key, project_name, project_dir, sources)
+        command = ["sonar-scanner"]
+        if not self._has_auth_configured():
+            if self.config.use_token_auth:
+                command.append(f"-Dsonar.token={self.config.sonarqube_token}")
+            else:
+                command.append(f"-Dsonar.login={self.config.sonarqube_username}")
+                command.append(f"-Dsonar.password={self.config.sonarqube_password}")
+        return command
+
+    def _build_full_command(
+        self,
+        project_key: str,
+        project_name: str,
+        project_dir: Path,
+        sources: list[Path] | None = None,
+    ) -> list[str]:
+        command = [
+            "sonar-scanner",
+            f"-Dsonar.projectKey={project_key}",
+            f"-Dsonar.projectName={project_name}",
+            f"-Dsonar.host.url={self.config.sonarqube_url}",
+        ]
+        if self.config.use_token_auth:
+            command.append(f"-Dsonar.token={self.config.sonarqube_token}")
+        else:
+            command.append(f"-Dsonar.login={self.config.sonarqube_username}")
+            command.append(f"-Dsonar.password={self.config.sonarqube_password}")
+        if sources:
+            command.append(f"-Dsonar.sources={','.join(str(s) for s in sources)}")
+        else:
+            command.append("-Dsonar.sources=.")
+        return command
+
+    def _has_auth_configured(self) -> bool:
+        for env_var in _AUTH_ENV_VARS:
+            if os.environ.get(env_var):
+                return True
+        if self.exists:
+            content = self.properties_file.read_text(encoding="utf-8")
+            for line in content.splitlines():
+                if line.lstrip().startswith("#"):
+                    continue
+                if _AUTH_PROPS_RE.match(line):
+                    return True
+        return False
+
+    def _extract_property(self, content: str, key: str) -> str | None:
+        pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.*)", re.IGNORECASE)
+        for line in content.splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            m = pattern.match(line)
+            if m:
+                return m.group(1).strip()
+        return None
+
+    @contextmanager
+    def patched(self, project_key: str, project_name: str) -> Generator[None, None, None]:
+        if not self.exists:
+            yield
+            return
+        original_content = self.properties_file.read_text(encoding="utf-8")
+        existing_key = self._extract_property(original_content, "sonar.projectKey")
+        if existing_key == project_key:
+            yield
+            return
+        patched_content = _patch_content(original_content, project_key, project_name)
+        self.properties_file.write_text(patched_content, encoding="utf-8")
+        try:
+            yield
+        finally:
+            try:
+                self.properties_file.write_text(original_content, encoding="utf-8")
+            except OSError:
+                logger.exception(
+                    "Failed to restore %s. Original content:\n%s",
+                    self.properties_file,
+                    original_content,
+                )
+
+
+def _find_key_name_indices(
+    lines: list[str],
+) -> tuple[int | None, int | None, str | None, str | None]:
+    """Return (key_idx, name_idx, orig_key_line, orig_name_line) from a properties file."""
+    key_idx: int | None = None
+    name_idx: int | None = None
+    orig_key_line: str | None = None
+    orig_name_line: str | None = None
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("#"):
+            continue
+        if _KEY_RE.match(line) and key_idx is None:
+            key_idx = i
+            orig_key_line = line.rstrip("\n").rstrip("\r")
+        elif _NAME_RE.match(line) and name_idx is None:
+            name_idx = i
+            orig_name_line = line.rstrip("\n").rstrip("\r")
+    return key_idx, name_idx, orig_key_line, orig_name_line
+
+
+def _build_recovery_block(
+    orig_key_line: str | None, orig_name_line: str | None, new_key: str, new_name: str
+) -> list[str]:
+    """Build the recovery comment block and new key/name lines."""
+    recovery: list[str] = [
+        "# vibe-heal: temporary analysis project. If this process was interrupted,\n",
+        "# restore the lines below (remove the '#' prefix):\n",
+    ]
+    if orig_key_line is not None:
+        recovery.append(f"# {orig_key_line.lstrip()}\n")
+    if orig_name_line is not None:
+        recovery.append(f"# {orig_name_line.lstrip()}\n")
+    recovery.append(f"sonar.projectKey={new_key}\n")
+    recovery.append(f"sonar.projectName={new_name}\n")
+    return recovery
+
+
+def _patch_content(content: str, new_key: str, new_name: str) -> str:
+    lines = content.splitlines(keepends=True)
+    key_idx, name_idx, orig_key_line, orig_name_line = _find_key_name_indices(lines)
+
+    recovery = _build_recovery_block(orig_key_line, orig_name_line, new_key, new_name)
+
+    present = [i for i in (key_idx, name_idx) if i is not None]
+    if not present:
+        return content + f"sonar.projectKey={new_key}\n" + f"sonar.projectName={new_name}\n"
+
+    first_idx = min(present)
+    skip = set(present)
+    result: list[str] = []
+    for i, line in enumerate(lines):
+        if i == first_idx:
+            result.extend(recovery)
+        if i not in skip:
+            result.append(line)
+    return "".join(result)

--- a/src/vibe_heal/sonarqube/properties_handler.py
+++ b/src/vibe_heal/sonarqube/properties_handler.py
@@ -16,7 +16,10 @@ PROPERTIES_FILENAME = "sonar-project.properties"
 _KEY_RE = re.compile(r"^\s*sonar\.projectKey\s*=", re.IGNORECASE)
 _NAME_RE = re.compile(r"^\s*sonar\.projectName\s*=", re.IGNORECASE)
 _AUTH_PROPS_RE = re.compile(r"^\s*sonar\.(token|login|password)\s*=\s*.+", re.IGNORECASE)
+_AUTH_REDACT_RE = re.compile(r"^\s*[#!]?\s*sonar\.(token|login|password)\s*=\s*.+", re.IGNORECASE)
 _AUTH_ENV_VARS = ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN")
+_HOST_URL_ENV_VARS = ("SONAR_HOST_URL", "SONARQUBE_HOST_URL")
+_HOST_URL_RE = re.compile(r"^\s*sonar\.host\.url\s*=\s*.+", re.IGNORECASE)
 
 
 class SonarPropertiesHandler:
@@ -40,6 +43,8 @@ class SonarPropertiesHandler:
         if not self.exists:
             return self._build_full_command(project_key, project_name, sources)
         command = ["sonar-scanner"]
+        if not self._has_host_url_configured():
+            command.append(f"-Dsonar.host.url={self.config.sonarqube_url}")
         if not self._has_auth_configured():
             if self.config.use_token_auth:
                 command.append(f"-Dsonar.token={self.config.sonarqube_token}")
@@ -84,6 +89,19 @@ class SonarPropertiesHandler:
                     return True
         return False
 
+    def _has_host_url_configured(self) -> bool:
+        for env_var in _HOST_URL_ENV_VARS:
+            if os.environ.get(env_var):
+                return True
+        if self.exists:
+            content = self.properties_file.read_text(encoding="utf-8")
+            for line in content.splitlines():
+                if line.lstrip().startswith("#"):
+                    continue
+                if _HOST_URL_RE.match(line):
+                    return True
+        return False
+
     def _extract_property(self, content: str, key: str) -> str | None:
         pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.*)", re.IGNORECASE)
         for line in content.splitlines():
@@ -124,7 +142,7 @@ def _redact_auth_properties(content: str) -> str:
 
     redacted_lines: list[str] = []
     for line in content.splitlines(keepends=True):
-        if _AUTH_PROPS_RE.match(line):
+        if _AUTH_REDACT_RE.match(line):
             key, sep, remainder = line.partition("=")
             line_ending = ""
             if remainder.endswith("\r\n"):
@@ -188,6 +206,8 @@ def _patch_content(content: str, new_key: str, new_name: str) -> str:
 
     all_indices = key_indices + name_indices
     if not all_indices:
+        if not content.endswith("\n"):
+            content += "\n"
         return content + f"sonar.projectKey={new_key}\n" + f"sonar.projectName={new_name}\n"
 
     first_idx = min(all_indices)

--- a/src/vibe_heal/sonarqube/properties_handler.py
+++ b/src/vibe_heal/sonarqube/properties_handler.py
@@ -113,10 +113,30 @@ class SonarPropertiesHandler:
                 self.properties_file.write_text(original_content, encoding="utf-8")
             except OSError:
                 logger.exception(
-                    "Failed to restore %s. Original content:\n%s",
+                    "Failed to restore %s. Original content (auth properties redacted):\n%s",
                     self.properties_file,
-                    original_content,
+                    _redact_auth_properties(original_content),
                 )
+
+
+def _redact_auth_properties(content: str) -> str:
+    """Redact auth-related sonar properties before logging file contents."""
+
+    redacted_lines: list[str] = []
+    for line in content.splitlines(keepends=True):
+        if _AUTH_PROPS_RE.match(line):
+            key, sep, remainder = line.partition("=")
+            line_ending = ""
+            if remainder.endswith("\r\n"):
+                line_ending = "\r\n"
+            elif remainder.endswith("\n"):
+                line_ending = "\n"
+            elif remainder.endswith("\r"):
+                line_ending = "\r"
+            redacted_lines.append(f"{key}{sep}<redacted>{line_ending}")
+        else:
+            redacted_lines.append(line)
+    return "".join(redacted_lines)
 
 
 def _find_key_name_indices(

--- a/tests/sonarqube/test_analysis_runner.py
+++ b/tests/sonarqube/test_analysis_runner.py
@@ -59,60 +59,6 @@ class TestValidateScannerAvailable:
             assert analysis_runner.validate_scanner_available() is False
 
 
-class TestGetScannerCommand:
-    """Tests for _get_scanner_command method."""
-
-    def test_basic_command(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
-        """Test basic scanner command generation."""
-        command = analysis_runner._get_scanner_command(
-            project_key="test-project",
-            project_name="Test Project",
-            project_dir=tmp_path,
-            sources=None,
-        )
-
-        assert "sonar-scanner" in command
-        assert "-Dsonar.projectKey=test-project" in command
-        assert "-Dsonar.projectName=Test Project" in command
-        assert "-Dsonar.host.url=https://sonar.test.com" in command
-        assert "-Dsonar.token=test-token" in command
-        assert "-Dsonar.sources=." in command
-
-    def test_command_with_sources(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
-        """Test scanner command with specific sources."""
-        sources = [Path("src/file1.py"), Path("src/file2.py")]
-
-        command = analysis_runner._get_scanner_command(
-            project_key="test-project",
-            project_name="Test Project",
-            project_dir=tmp_path,
-            sources=sources,
-        )
-
-        assert "-Dsonar.sources=src/file1.py,src/file2.py" in command
-
-    def test_command_with_basic_auth(self, mock_client: AsyncMock, tmp_path: Path) -> None:
-        """Test scanner command with basic auth instead of token."""
-        config = VibeHealConfig(
-            sonarqube_url="https://sonar.test.com",
-            sonarqube_username="testuser",
-            sonarqube_password="testpass",
-            sonarqube_project_key="my-project",
-        )
-        runner = AnalysisRunner(config, mock_client)
-
-        command = runner._get_scanner_command(
-            project_key="test-project",
-            project_name="Test Project",
-            project_dir=tmp_path,
-            sources=None,
-        )
-
-        assert "-Dsonar.login=testuser" in command
-        assert "-Dsonar.password=testpass" in command
-        assert "-Dsonar.token" not in " ".join(command)
-
-
 class TestExtractTaskId:
     """Tests for _extract_task_id method."""
 
@@ -418,3 +364,60 @@ class TestAnalysisResult:
         assert result.error_message == "Analysis failed"
         assert result.task_id is None
         assert result.dashboard_url is None
+
+
+class TestAuthHint:
+    @pytest.mark.asyncio
+    async def test_auth_hint_added_when_properties_file_and_auth_error(
+        self, analysis_runner: AnalysisRunner, tmp_path: Path
+    ) -> None:
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        mock_process = AsyncMock()
+        mock_process.returncode = 1
+        mock_process.communicate = AsyncMock(return_value=(b"", b"ERROR: 401 Unauthorized"))
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="temp-key",
+                project_name="Temp",
+                project_dir=tmp_path,
+            )
+        assert result.success is False
+        assert "SONAR_TOKEN" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_no_auth_hint_without_properties_file(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
+        mock_process = AsyncMock()
+        mock_process.returncode = 1
+        mock_process.communicate = AsyncMock(return_value=(b"", b"ERROR: 401 Unauthorized"))
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="test-key",
+                project_name="Test",
+                project_dir=tmp_path,
+            )
+        assert result.success is False
+        assert "SONAR_TOKEN" not in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_no_auth_hint_for_non_auth_failure(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        mock_process = AsyncMock()
+        mock_process.returncode = 1
+        mock_process.communicate = AsyncMock(return_value=(b"", b"ERROR: Project not found"))
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="temp-key",
+                project_name="Temp",
+                project_dir=tmp_path,
+            )
+        assert result.success is False
+        assert "SONAR_TOKEN" not in result.error_message

--- a/tests/sonarqube/test_project_manager.py
+++ b/tests/sonarqube/test_project_manager.py
@@ -58,11 +58,11 @@ class TestCreateTempProject:
         assert timestamp[:6].isdigit()  # yymmdd
         assert timestamp[7:].isdigit()  # hhmm
 
-        # Verify project was created with the generated key
-        mock_client.create_project.assert_called_once_with(metadata.project_key, metadata.project_key)
+        # Verify project was created with the generated key and human-readable name
+        mock_client.create_project.assert_called_once_with(metadata.project_key, metadata.project_name)
 
         # Verify metadata
-        assert metadata.project_name == metadata.project_key
+        assert metadata.project_name == "my_project analysis user feature-new-api"
         assert metadata.base_project_key == base_key
         assert metadata.branch_name == branch_name
         assert metadata.user_email == user_email
@@ -87,7 +87,7 @@ class TestCreateTempProject:
         expected_prefix = "project_user_tag_example_co_uk_main_"
         assert metadata.project_key.startswith(expected_prefix)
         # Verify project was created with the generated key (including timestamp)
-        mock_client.create_project.assert_called_once_with(metadata.project_key, metadata.project_key)
+        mock_client.create_project.assert_called_once_with(metadata.project_key, metadata.project_name)
 
     @pytest.mark.asyncio
     async def test_create_temp_project_sanitizes_branch(
@@ -132,6 +132,57 @@ class TestCreateTempProject:
         assert metadata1.project_key != metadata2.project_key
         assert metadata1.project_key != metadata3.project_key
         assert metadata2.project_key != metadata3.project_key
+
+    @pytest.mark.asyncio
+    async def test_project_name_format_with_command(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="my-project",
+            branch_name="feature/add-login",
+            user_email="alexei.eleusis@gmail.com",
+            command_name="review",
+        )
+        assert metadata.project_name == "my-project review alexei.eleusis feature-add-login"
+
+    @pytest.mark.asyncio
+    async def test_project_name_uses_default_command_name(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="my-project",
+            branch_name="main",
+            user_email="user@example.com",
+        )
+        assert metadata.project_name == "my-project analysis user main"
+
+    @pytest.mark.asyncio
+    async def test_project_name_email_without_at_sign(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="proj",
+            branch_name="main",
+            user_email="localonly",
+            command_name="cleanup",
+        )
+        assert metadata.project_name == "proj cleanup localonly main"
+
+    @pytest.mark.asyncio
+    async def test_project_name_branch_slashes_become_dashes(
+        self, project_manager: ProjectManager, mock_client: AsyncMock
+    ) -> None:
+        mock_client.create_project = AsyncMock()
+        metadata = await project_manager.create_temp_project(
+            base_key="proj",
+            branch_name="feature/nested/branch",
+            user_email="u@t.com",
+            command_name="dedupe-branch",
+        )
+        assert metadata.project_name == "proj dedupe-branch u feature-nested-branch"
 
 
 class TestDeleteProject:

--- a/tests/sonarqube/test_properties_handler.py
+++ b/tests/sonarqube/test_properties_handler.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from vibe_heal.config import VibeHealConfig
-from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler
+from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler, _patch_content
 
 
 @pytest.fixture
@@ -172,3 +172,77 @@ class TestBuildCommandWithFile:
         handler = SonarPropertiesHandler(tmp_path, config)
         cmd = handler.build_command("key", "Name", sources=[Path("src/a.py")])
         assert not any("sonar.sources" in arg for arg in cmd)
+
+
+class TestPatchContent:
+    def test_replaces_key_and_name_with_recovery_block(self) -> None:
+        original = "sonar.projectKey=my-project\nsonar.projectName=My Project\nsonar.sources=.\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        assert "sonar.projectKey=temp-key-123" in result
+        assert "sonar.projectName=my-project review user main" in result
+        assert "# sonar.projectKey=my-project" in result
+        assert "# sonar.projectName=My Project" in result
+        assert "vibe-heal: temporary analysis project" in result
+        assert "sonar.sources=." in result  # unrelated line preserved
+
+    def test_key_only_in_file_appends_new_name(self) -> None:
+        original = "sonar.projectKey=my-project\nsonar.sources=.\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        assert "sonar.projectKey=temp-key-123" in result
+        assert "sonar.projectName=my-project review user main" in result
+        assert "# sonar.projectKey=my-project" in result
+        assert "sonar.sources=." in result
+
+    def test_neither_key_nor_name_appended_at_end(self) -> None:
+        original = "sonar.sources=.\nsonar.host.url=https://sonar.test.com\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        assert result.endswith("sonar.projectKey=temp-key-123\nsonar.projectName=my-project review user main\n")
+        assert "sonar.sources=." in result
+
+    def test_commented_key_line_not_treated_as_property(self) -> None:
+        original = "# sonar.projectKey=commented\nsonar.sources=.\n"
+        result = _patch_content(original, "temp-key-123", "my-project review user main")
+        # No real key found, so values appended at end
+        assert result.endswith("sonar.projectKey=temp-key-123\nsonar.projectName=my-project review user main\n")
+
+
+class TestPatched:
+    def test_patches_file_during_with_block(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        props = tmp_path / "sonar-project.properties"
+        props.write_text("sonar.projectKey=original\nsonar.sources=.\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("temp-key", "Temp Name"):
+            content = props.read_text()
+            assert "sonar.projectKey=temp-key" in content
+            assert "# sonar.projectKey=original" in content
+
+    def test_restores_file_after_normal_exit(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        original = "sonar.projectKey=original\nsonar.sources=.\n"
+        props = tmp_path / "sonar-project.properties"
+        props.write_text(original)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("temp-key", "Temp Name"):
+            pass
+        assert props.read_text() == original
+
+    def test_restores_file_after_exception(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        original = "sonar.projectKey=original\nsonar.sources=.\n"
+        props = tmp_path / "sonar-project.properties"
+        props.write_text(original)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with pytest.raises(ValueError), handler.patched("temp-key", "Temp Name"):
+            raise ValueError("simulated failure")
+        assert props.read_text() == original
+
+    def test_noop_when_file_absent(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("temp-key", "Temp Name"):
+            pass  # must not raise
+
+    def test_noop_when_key_already_matches(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        original = "sonar.projectKey=same-key\n"
+        props = tmp_path / "sonar-project.properties"
+        props.write_text(original)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        with handler.patched("same-key", "Same Name"):
+            assert props.read_text() == original  # file untouched

--- a/tests/sonarqube/test_properties_handler.py
+++ b/tests/sonarqube/test_properties_handler.py
@@ -205,6 +205,26 @@ class TestPatchContent:
         # No real key found, so values appended at end
         assert result.endswith("sonar.projectKey=temp-key-123\nsonar.projectName=my-project review user main\n")
 
+    def test_duplicate_key_name_lines_all_removed(self) -> None:
+        original = (
+            "sonar.projectKey=first-project\n"
+            "sonar.projectName=First Project\n"
+            "sonar.sources=.\n"
+            "sonar.projectKey=second-project\n"
+            "sonar.projectName=Second Project\n"
+        )
+        result = _patch_content(original, "temp-key-123", "Temp Name")
+        assert "sonar.projectKey=temp-key-123" in result
+        assert "sonar.projectName=Temp Name" in result
+        # Duplicate lines should be removed; first-project is gone entirely
+        assert "first-project" not in result
+        # second-project appears only as a recovery comment, not as an active key line
+        assert "\nsonar.projectKey=second-project\n" not in result
+        # The recovery comment should reference the last (active) values
+        assert "# sonar.projectKey=second-project" in result
+        assert "# sonar.projectName=Second Project" in result
+        assert "sonar.sources=." in result
+
 
 class TestPatched:
     def test_patches_file_during_with_block(self, tmp_path: Path, config: VibeHealConfig) -> None:

--- a/tests/sonarqube/test_properties_handler.py
+++ b/tests/sonarqube/test_properties_handler.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from vibe_heal.config import VibeHealConfig
-from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler, _patch_content
+from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler, _patch_content, _redact_auth_properties
 
 
 @pytest.fixture
@@ -133,7 +133,7 @@ class TestBuildCommandWithFile:
         (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\nsonar.token=file-token\n")
         handler = SonarPropertiesHandler(tmp_path, config)
         cmd = handler.build_command("temp-key", "Temp Name")
-        assert cmd == ["sonar-scanner"]
+        assert cmd == ["sonar-scanner", "-Dsonar.host.url=https://sonar.test.com"]
 
     def test_minimal_command_when_auth_in_env(
         self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
@@ -142,7 +142,7 @@ class TestBuildCommandWithFile:
         (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
         handler = SonarPropertiesHandler(tmp_path, config)
         cmd = handler.build_command("temp-key", "Temp Name")
-        assert cmd == ["sonar-scanner"]
+        assert cmd == ["sonar-scanner", "-Dsonar.host.url=https://sonar.test.com"]
 
     def test_injects_token_fallback_when_no_auth(
         self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
@@ -152,7 +152,7 @@ class TestBuildCommandWithFile:
         (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
         handler = SonarPropertiesHandler(tmp_path, config)
         cmd = handler.build_command("temp-key", "Temp Name")
-        assert cmd == ["sonar-scanner", "-Dsonar.token=test-token"]
+        assert cmd == ["sonar-scanner", "-Dsonar.host.url=https://sonar.test.com", "-Dsonar.token=test-token"]
 
     def test_injects_basic_auth_fallback_when_no_auth(
         self, tmp_path: Path, basic_auth_config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
@@ -162,7 +162,12 @@ class TestBuildCommandWithFile:
         (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
         handler = SonarPropertiesHandler(tmp_path, basic_auth_config)
         cmd = handler.build_command("temp-key", "Temp Name")
-        assert cmd == ["sonar-scanner", "-Dsonar.login=user", "-Dsonar.password=pass"]
+        assert cmd == [
+            "sonar-scanner",
+            "-Dsonar.host.url=https://sonar.test.com",
+            "-Dsonar.login=user",
+            "-Dsonar.password=pass",
+        ]
 
     def test_sources_not_injected_when_file_present(
         self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
@@ -172,6 +177,36 @@ class TestBuildCommandWithFile:
         handler = SonarPropertiesHandler(tmp_path, config)
         cmd = handler.build_command("key", "Name", sources=[Path("src/a.py")])
         assert not any("sonar.sources" in arg for arg in cmd)
+
+    def test_host_url_not_injected_when_configured_in_file(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "tok")
+        (tmp_path / "sonar-project.properties").write_text(
+            "sonar.projectKey=orig\nsonar.host.url=https://other.test.com\n"
+        )
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name")
+        assert not any("sonar.host.url" in arg for arg in cmd)
+
+    def test_host_url_not_injected_when_configured_in_env(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "tok")
+        monkeypatch.setenv("SONAR_HOST_URL", "https://env.test.com")
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name")
+        assert not any("sonar.host.url" in arg for arg in cmd)
+
+    def test_host_url_injected_when_not_configured(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "tok")
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name")
+        assert "-Dsonar.host.url=https://sonar.test.com" in cmd
 
 
 class TestPatchContent:
@@ -204,6 +239,13 @@ class TestPatchContent:
         result = _patch_content(original, "temp-key-123", "my-project review user main")
         # No real key found, so values appended at end
         assert result.endswith("sonar.projectKey=temp-key-123\nsonar.projectName=my-project review user main\n")
+
+    def test_appends_newline_when_content_has_no_trailing_newline(self) -> None:
+        original = "sonar.sources=."
+        result = _patch_content(original, "temp-key-123", "Temp Name")
+        assert "sonar.sources=.\n" in result
+        assert "sonar.sources=.sonar.projectKey" not in result
+        assert result.endswith("sonar.projectKey=temp-key-123\nsonar.projectName=Temp Name\n")
 
     def test_duplicate_key_name_lines_all_removed(self) -> None:
         original = (
@@ -266,3 +308,34 @@ class TestPatched:
         handler = SonarPropertiesHandler(tmp_path, config)
         with handler.patched("same-key", "Same Name"):
             assert props.read_text() == original  # file untouched
+
+
+class TestRedactAuthProperties:
+    def test_redacts_uncommented_token(self) -> None:
+        result = _redact_auth_properties("sonar.token=my-secret\n")
+        assert "my-secret" not in result
+        assert "<redacted>" in result
+
+    def test_redacts_commented_token_with_hash(self) -> None:
+        result = _redact_auth_properties("# sonar.token=my-secret\n")
+        assert "my-secret" not in result
+        assert "<redacted>" in result
+
+    def test_redacts_commented_token_with_exclamation(self) -> None:
+        result = _redact_auth_properties("! sonar.login=user123\n")
+        assert "user123" not in result
+        assert "<redacted>" in result
+
+    def test_redacts_password_in_file(self) -> None:
+        result = _redact_auth_properties("  sonar.password=p@ssw0rd\n")
+        assert "p@ssw0rd" not in result
+        assert "<redacted>" in result
+
+    def test_preserves_non_auth_lines(self) -> None:
+        original = "sonar.projectKey=my-project\nsonar.token=secret123\nsonar.sources=.\n# sonar.password=oldpass\n"
+        result = _redact_auth_properties(original)
+        assert "sonar.projectKey=my-project\n" in result
+        assert "sonar.sources=.\n" in result
+        assert "secret123" not in result
+        assert "oldpass" not in result
+        assert result.count("<redacted>") == 2

--- a/tests/sonarqube/test_properties_handler.py
+++ b/tests/sonarqube/test_properties_handler.py
@@ -64,3 +64,111 @@ class TestBuildCommandNoFile:
         assert "-Dsonar.login=user" in cmd
         assert "-Dsonar.password=pass" in cmd
         assert not any("sonar.token" in arg for arg in cmd)
+
+
+class TestHasAuthConfigured:
+    def test_false_when_nothing_set(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is False
+
+    def test_true_via_sonar_token_env(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "secret")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_sonarqube_token_env(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONARQUBE_TOKEN", "secret")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_sonar_login_env(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONAR_LOGIN", "user")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_token_in_file(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.token=file-token\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_true_via_login_in_file(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.login=user\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is True
+
+    def test_commented_token_line_not_counted(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("# sonar.token=commented\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler._has_auth_configured() is False
+
+
+class TestBuildCommandWithFile:
+    def test_minimal_command_when_auth_in_file(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\nsonar.token=file-token\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name")
+        assert cmd == ["sonar-scanner"]
+
+    def test_minimal_command_when_auth_in_env(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "env-token")
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name")
+        assert cmd == ["sonar-scanner"]
+
+    def test_injects_token_fallback_when_no_auth(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("temp-key", "Temp Name")
+        assert cmd == ["sonar-scanner", "-Dsonar.token=test-token"]
+
+    def test_injects_basic_auth_fallback_when_no_auth(
+        self, tmp_path: Path, basic_auth_config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("SONAR_TOKEN", "SONARQUBE_TOKEN", "SONAR_LOGIN"):
+            monkeypatch.delenv(v, raising=False)
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, basic_auth_config)
+        cmd = handler.build_command("temp-key", "Temp Name")
+        assert cmd == ["sonar-scanner", "-Dsonar.login=user", "-Dsonar.password=pass"]
+
+    def test_sources_not_injected_when_file_present(
+        self, tmp_path: Path, config: VibeHealConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONAR_TOKEN", "tok")
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=orig\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("key", "Name", sources=[Path("src/a.py")])
+        assert not any("sonar.sources" in arg for arg in cmd)

--- a/tests/sonarqube/test_properties_handler.py
+++ b/tests/sonarqube/test_properties_handler.py
@@ -1,0 +1,66 @@
+"""Tests for SonarPropertiesHandler."""
+
+from pathlib import Path
+
+import pytest
+
+from vibe_heal.config import VibeHealConfig
+from vibe_heal.sonarqube.properties_handler import SonarPropertiesHandler
+
+
+@pytest.fixture
+def config() -> VibeHealConfig:
+    return VibeHealConfig(
+        sonarqube_url="https://sonar.test.com",
+        sonarqube_token="test-token",
+        sonarqube_project_key="my-project",
+    )
+
+
+@pytest.fixture
+def basic_auth_config() -> VibeHealConfig:
+    return VibeHealConfig(
+        sonarqube_url="https://sonar.test.com",
+        sonarqube_username="user",
+        sonarqube_password="pass",
+        sonarqube_project_key="my-project",
+    )
+
+
+class TestExists:
+    def test_false_when_file_absent(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler.exists is False
+
+    def test_true_when_file_present(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        (tmp_path / "sonar-project.properties").write_text("sonar.projectKey=x\n")
+        handler = SonarPropertiesHandler(tmp_path, config)
+        assert handler.exists is True
+
+
+class TestBuildCommandNoFile:
+    def test_includes_all_d_flags_token_auth(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("test-key", "Test Project", tmp_path)
+        assert "-Dsonar.projectKey=test-key" in cmd
+        assert "-Dsonar.projectName=Test Project" in cmd
+        assert "-Dsonar.host.url=https://sonar.test.com" in cmd
+        assert "-Dsonar.token=test-token" in cmd
+        assert "-Dsonar.sources=." in cmd
+
+    def test_default_sources_dot(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("key", "Name", tmp_path, sources=None)
+        assert "-Dsonar.sources=." in cmd
+
+    def test_explicit_sources(self, tmp_path: Path, config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, config)
+        cmd = handler.build_command("key", "Name", tmp_path, sources=[Path("src/a.py"), Path("src/b.py")])
+        assert "-Dsonar.sources=src/a.py,src/b.py" in cmd
+
+    def test_basic_auth(self, tmp_path: Path, basic_auth_config: VibeHealConfig) -> None:
+        handler = SonarPropertiesHandler(tmp_path, basic_auth_config)
+        cmd = handler.build_command("key", "Name", tmp_path)
+        assert "-Dsonar.login=user" in cmd
+        assert "-Dsonar.password=pass" in cmd
+        assert not any("sonar.token" in arg for arg in cmd)

--- a/tests/sonarqube/test_properties_handler.py
+++ b/tests/sonarqube/test_properties_handler.py
@@ -41,7 +41,7 @@ class TestExists:
 class TestBuildCommandNoFile:
     def test_includes_all_d_flags_token_auth(self, tmp_path: Path, config: VibeHealConfig) -> None:
         handler = SonarPropertiesHandler(tmp_path, config)
-        cmd = handler.build_command("test-key", "Test Project", tmp_path)
+        cmd = handler.build_command("test-key", "Test Project")
         assert "-Dsonar.projectKey=test-key" in cmd
         assert "-Dsonar.projectName=Test Project" in cmd
         assert "-Dsonar.host.url=https://sonar.test.com" in cmd
@@ -50,17 +50,17 @@ class TestBuildCommandNoFile:
 
     def test_default_sources_dot(self, tmp_path: Path, config: VibeHealConfig) -> None:
         handler = SonarPropertiesHandler(tmp_path, config)
-        cmd = handler.build_command("key", "Name", tmp_path, sources=None)
+        cmd = handler.build_command("key", "Name", sources=None)
         assert "-Dsonar.sources=." in cmd
 
     def test_explicit_sources(self, tmp_path: Path, config: VibeHealConfig) -> None:
         handler = SonarPropertiesHandler(tmp_path, config)
-        cmd = handler.build_command("key", "Name", tmp_path, sources=[Path("src/a.py"), Path("src/b.py")])
+        cmd = handler.build_command("key", "Name", sources=[Path("src/a.py"), Path("src/b.py")])
         assert "-Dsonar.sources=src/a.py,src/b.py" in cmd
 
     def test_basic_auth(self, tmp_path: Path, basic_auth_config: VibeHealConfig) -> None:
         handler = SonarPropertiesHandler(tmp_path, basic_auth_config)
-        cmd = handler.build_command("key", "Name", tmp_path)
+        cmd = handler.build_command("key", "Name")
         assert "-Dsonar.login=user" in cmd
         assert "-Dsonar.password=pass" in cmd
         assert not any("sonar.token" in arg for arg in cmd)


### PR DESCRIPTION
## Summary

- Introduces `SonarPropertiesHandler` — detects `sonar-project.properties` and builds a minimal `sonar-scanner` command (no redundant `-D` flags) when the file is present, falling back to the existing full command when absent
- Patches `sonar.projectKey` / `sonar.projectName` in-place before running the scanner for temp-project workflows (review, cleanup, dedupe-branch), with recovery comments and unconditional `finally` restore
- Auth token injected only as a fallback when not already covered by env vars (`SONAR_TOKEN`, `SONARQUBE_TOKEN`, `SONAR_LOGIN`) or the properties file; auth failures include a hint pointing at env vars and `~/.sonar/sonar-scanner.properties`
- Temp project display name now includes command, email local part, and branch: `"{base_key} {command_name} {email_local} {branch-with-dashes}"`

## Test Plan

- [ ] `pytest` — 493 tests pass, including 27 new tests for `SonarPropertiesHandler` and 3 new auth-hint tests in `test_analysis_runner.py`
- [ ] Run `vibe-heal cleanup` / `vibe-heal review` in a repo with `sonar-project.properties` and verify the scanner picks up file settings without duplicate `-D` flags
- [ ] Verify the properties file is restored to original content after the run (including after Ctrl-C)
- [ ] Verify auth hint appears when scanner returns 401/403 and properties file is present

Fixes #126 

🤖 Generated with [Claude Code](https://claude.com/claude-code)