### PR TITLE
fix: include same-file duplicates in review command's other_locations

### DIFF
--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -457,14 +457,20 @@ class ReviewOrchestrator:
         # PR comment is attached to a line that is actually in the diff.
         anchor_line = min(changed_in_block)
         other_locations = []
-        for block in group.get_other_blocks(target_ref):
+        # Skip only the specific target block instance (by identity), not all
+        # blocks sharing the same ref. This preserves same-file duplicates in
+        # the other_locations list.
+        target_block_id = id(target_block)
+        for block in group.blocks:
+            if id(block) == target_block_id:
+                continue
             file_info = response.get_file_info(block.ref)
             if file_info is None:
                 continue
-            other_file_path = file_info.key.split(":", 1)[1] if ":" in file_info.key else file_info.key
+            block_file_path = file_info.key.split(":", 1)[1] if ":" in file_info.key else file_info.key
             other_locations.append(
                 DuplicationLocation(
-                    file_path=other_file_path,
+                    file_path=block_file_path,
                     from_line=block.from_line,
                     to_line=block.to_line,
                 )
@@ -567,14 +573,20 @@ class ReviewOrchestrator:
         if any(a_from <= target_block.to_line and a_to >= target_block.from_line for a_from, a_to in active_dup_ranges):
             return None
         other_locations = []
-        for block in group.get_other_blocks(target_ref):
+        # Skip only the specific target block instance (by identity), not all
+        # blocks sharing the same ref. This preserves same-file duplicates in
+        # the other_locations list.
+        target_block_id = id(target_block)
+        for block in group.blocks:
+            if id(block) == target_block_id:
+                continue
             file_info = response.get_file_info(block.ref)
             if file_info is None:
                 continue
-            other_file_path = file_info.key.split(":", 1)[1] if ":" in file_info.key else file_info.key
+            block_file_path = file_info.key.split(":", 1)[1] if ":" in file_info.key else file_info.key
             other_locations.append(
                 DuplicationLocation(
-                    file_path=other_file_path,
+                    file_path=block_file_path,
                     from_line=block.from_line,
                     to_line=block.to_line,
                 )

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -7,7 +7,7 @@ from rich.console import Console
 
 from vibe_heal.config import VibeHealConfig
 from vibe_heal.deduplication.client import DuplicationClient
-from vibe_heal.deduplication.models import DuplicationGroup, DuplicationsResponse
+from vibe_heal.deduplication.models import DuplicationBlock, DuplicationGroup, DuplicationsResponse
 from vibe_heal.git.branch_analyzer import BranchAnalyzer
 from vibe_heal.git.diff_parser import DiffParser
 from vibe_heal.review.github import GitHubReviewClient
@@ -456,13 +456,28 @@ class ReviewOrchestrator:
         # Use the lowest changed line in the block as the anchor so the GitHub
         # PR comment is attached to a line that is actually in the diff.
         anchor_line = min(changed_in_block)
-        other_locations = []
-        # Skip only the specific target block instance (by identity), not all
-        # blocks sharing the same ref. This preserves same-file duplicates in
-        # the other_locations list.
-        target_block_id = id(target_block)
+        other_locations = self._build_other_locations(group, target_block, response)
+        return ReviewDuplication(
+            from_line=target_block.from_line,
+            to_line=target_block.to_line,
+            anchor_line=anchor_line,
+            other_locations=other_locations,
+        )
+
+    def _build_other_locations(
+        self,
+        group: DuplicationGroup,
+        target_block: DuplicationBlock,
+        response: DuplicationsResponse,
+    ) -> list[DuplicationLocation]:
+        """Build other_locations by iterating all blocks and skipping only the target block.
+
+        Preserves same-file duplicates by skipping only the specific target block
+        instance (by identity) rather than excluding all blocks with the same ref.
+        """
+        other_locations: list[DuplicationLocation] = []
         for block in group.blocks:
-            if id(block) == target_block_id:
+            if block is target_block:
                 continue
             file_info = response.get_file_info(block.ref)
             if file_info is None:
@@ -475,12 +490,7 @@ class ReviewOrchestrator:
                     to_line=block.to_line,
                 )
             )
-        return ReviewDuplication(
-            from_line=target_block.from_line,
-            to_line=target_block.to_line,
-            anchor_line=anchor_line,
-            other_locations=other_locations,
-        )
+        return other_locations
 
     async def _get_resolved_duplications(
         self,
@@ -572,25 +582,7 @@ class ReviewOrchestrator:
         # the ranges are unlikely to match exactly after edits).
         if any(a_from <= target_block.to_line and a_to >= target_block.from_line for a_from, a_to in active_dup_ranges):
             return None
-        other_locations = []
-        # Skip only the specific target block instance (by identity), not all
-        # blocks sharing the same ref. This preserves same-file duplicates in
-        # the other_locations list.
-        target_block_id = id(target_block)
-        for block in group.blocks:
-            if id(block) == target_block_id:
-                continue
-            file_info = response.get_file_info(block.ref)
-            if file_info is None:
-                continue
-            block_file_path = file_info.key.split(":", 1)[1] if ":" in file_info.key else file_info.key
-            other_locations.append(
-                DuplicationLocation(
-                    file_path=block_file_path,
-                    from_line=block.from_line,
-                    to_line=block.to_line,
-                )
-            )
+        other_locations = self._build_other_locations(group, target_block, response)
         # Choose the new-side anchor closest to the block so the GitHub PR comment
         # is attached near the relevant change rather than an unrelated hunk.
         anchor_new_line = min(new_changed_lines, key=lambda ln: abs(ln - target_block.from_line))

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -769,48 +769,6 @@ class TestGetActiveDuplications:
         assert result == []
         assert diag.active_dup_api_status.startswith("error:ValueError:")
 
-    @pytest.mark.asyncio
-    async def test_same_file_duplication_includes_other_locations(self, orchestrator) -> None:
-        """When both duplication blocks are in the same file (same _ref), the other
-        block should still appear in other_locations."""
-        from vibe_heal.deduplication.models import DuplicationBlock, DuplicationGroup, DuplicationsResponse
-
-        # Both blocks share _ref="1" (same file)
-        target_block = DuplicationBlock(**{"from": 171, "size": 35, "_ref": "1"})
-        other_block = DuplicationBlock(**{"from": 249, "size": 35, "_ref": "1"})
-        group = DuplicationGroup(blocks=[target_block, other_block])
-
-        file_info = MagicMock()
-        file_info.key = "temp-project:src/file.py"
-
-        response = MagicMock(spec=DuplicationsResponse)
-        response.duplications = [group]
-        response.get_target_file_ref.return_value = "1"
-        response.get_file_info.return_value = file_info
-
-        mock_dup_instance = AsyncMock()
-        mock_dup_instance.get_duplications_for_file.return_value = response
-
-        with patch("vibe_heal.review.orchestrator.DuplicationClient") as MockDupClient:
-            MockDupClient.return_value.__aenter__ = AsyncMock(return_value=mock_dup_instance)
-            MockDupClient.return_value.__aexit__ = AsyncMock(return_value=None)
-
-            diag = self._make_diag()
-            result = await orchestrator._get_active_duplications(
-                Path("src/file.py"),
-                {"src/file.py": {180, 190}},  # lines inside the target block
-                diag,
-                project_key="temp-project",
-            )
-
-        assert len(result) == 1
-        assert result[0].from_line == 171
-        assert result[0].to_line == 205
-        assert len(result[0].other_locations) == 1
-        assert result[0].other_locations[0].file_path == "src/file.py"
-        assert result[0].other_locations[0].from_line == 249
-        assert result[0].other_locations[0].to_line == 283
-
 
 class TestGetResolvedDuplications:
     """Tests for ReviewOrchestrator._get_resolved_duplications()."""
@@ -978,19 +936,68 @@ class TestGetResolvedDuplications:
         # Orchestrator's own config must be untouched
         assert orchestrator.config.sonarqube_project_key == "temp-project"
 
+
+class TestSameFileDuplication:
+    """Tests for same-file duplication behavior in both active and resolved flows."""
+
+    @pytest.fixture
+    def orchestrator(self) -> ReviewOrchestrator:
+        from vibe_heal.config import VibeHealConfig
+        from vibe_heal.review.orchestrator import ReviewOrchestrator
+
+        config = VibeHealConfig(
+            sonarqube_url="https://sonar.test.com",
+            sonarqube_token="test-token",
+            sonarqube_project_key="temp-project",
+        )
+        mock_client = AsyncMock()
+        mock_client.config = config
+        mock_analyzer = MagicMock()
+        mock_analyzer.repo.working_dir = "/repo"
+        mock_parser = MagicMock()
+        return ReviewOrchestrator(config, mock_client, mock_analyzer, mock_parser)
+
     @pytest.mark.asyncio
-    async def test_same_file_resolved_duplication_includes_other_locations(self, orchestrator) -> None:
-        """When both duplication blocks are in the same file (same _ref) on main,
-        the other block should still appear in other_locations for resolved dups."""
+    @pytest.mark.parametrize(
+        "case_id,project_key,file_key_prefix,expected_from_attr,expected_to_attr",
+        [
+            pytest.param(
+                "active",
+                "temp-project",
+                "temp-project:src/file.py",
+                "from_line",
+                "to_line",
+                id="active",
+            ),
+            pytest.param(
+                "resolved",
+                "main-project",
+                "main-project:src/file.py",
+                "main_from_line",
+                "main_to_line",
+                id="resolved",
+            ),
+        ],
+    )
+    async def test_same_file_duplication_includes_other_locations(
+        self,
+        orchestrator,
+        case_id: str,
+        project_key: str,
+        file_key_prefix: str,
+        expected_from_attr: str,
+        expected_to_attr: str,
+    ) -> None:
+        """When both duplication blocks are in the same file (same _ref), the other
+        block should still appear in other_locations for both active and resolved flows."""
         from vibe_heal.deduplication.models import DuplicationBlock, DuplicationGroup, DuplicationsResponse
 
-        # Both blocks share _ref="1" (same file)
         target_block = DuplicationBlock(**{"from": 171, "size": 35, "_ref": "1"})
         other_block = DuplicationBlock(**{"from": 249, "size": 35, "_ref": "1"})
         group = DuplicationGroup(blocks=[target_block, other_block])
 
         file_info = MagicMock()
-        file_info.key = "main-project:src/file.py"
+        file_info.key = file_key_prefix
 
         response = MagicMock(spec=DuplicationsResponse)
         response.duplications = [group]
@@ -1000,23 +1007,32 @@ class TestGetResolvedDuplications:
         mock_dup_instance = AsyncMock()
         mock_dup_instance.get_duplications_for_file.return_value = response
 
+        diag = FileDiagnostics(file_path="src/file.py", lookup_key="src/file.py")
+
         with patch("vibe_heal.review.orchestrator.DuplicationClient") as MockDupClient:
             MockDupClient.return_value.__aenter__ = AsyncMock(return_value=mock_dup_instance)
             MockDupClient.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            diag = self._make_diag()
-            result = await orchestrator._get_resolved_duplications(
-                Path("src/file.py"),
-                changed_lines_map={"src/file.py": {180}},  # new changed lines
-                old_changed_lines_map={"src/file.py": {180}},  # old lines inside block
-                active_dup_ranges=set(),  # not covered by active dups
-                original_project_key="main-project",
-                diag=diag,
-            )
+            if case_id == "active":
+                result = await orchestrator._get_active_duplications(
+                    Path("src/file.py"),
+                    {"src/file.py": {180, 190}},
+                    diag,
+                    project_key=project_key,
+                )
+            else:
+                result = await orchestrator._get_resolved_duplications(
+                    Path("src/file.py"),
+                    changed_lines_map={"src/file.py": {180}},
+                    old_changed_lines_map={"src/file.py": {180}},
+                    active_dup_ranges=set(),
+                    original_project_key=project_key,
+                    diag=diag,
+                )
 
         assert len(result) == 1
-        assert result[0].main_from_line == 171
-        assert result[0].main_to_line == 205
+        assert getattr(result[0], expected_from_attr) == 171
+        assert getattr(result[0], expected_to_attr) == 205
         assert len(result[0].other_locations) == 1
         assert result[0].other_locations[0].file_path == "src/file.py"
         assert result[0].other_locations[0].from_line == 249

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -769,6 +769,48 @@ class TestGetActiveDuplications:
         assert result == []
         assert diag.active_dup_api_status.startswith("error:ValueError:")
 
+    @pytest.mark.asyncio
+    async def test_same_file_duplication_includes_other_locations(self, orchestrator) -> None:
+        """When both duplication blocks are in the same file (same _ref), the other
+        block should still appear in other_locations."""
+        from vibe_heal.deduplication.models import DuplicationBlock, DuplicationGroup, DuplicationsResponse
+
+        # Both blocks share _ref="1" (same file)
+        target_block = DuplicationBlock(**{"from": 171, "size": 35, "_ref": "1"})
+        other_block = DuplicationBlock(**{"from": 249, "size": 35, "_ref": "1"})
+        group = DuplicationGroup(blocks=[target_block, other_block])
+
+        file_info = MagicMock()
+        file_info.key = "temp-project:src/file.py"
+
+        response = MagicMock(spec=DuplicationsResponse)
+        response.duplications = [group]
+        response.get_target_file_ref.return_value = "1"
+        response.get_file_info.return_value = file_info
+
+        mock_dup_instance = AsyncMock()
+        mock_dup_instance.get_duplications_for_file.return_value = response
+
+        with patch("vibe_heal.review.orchestrator.DuplicationClient") as MockDupClient:
+            MockDupClient.return_value.__aenter__ = AsyncMock(return_value=mock_dup_instance)
+            MockDupClient.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            diag = self._make_diag()
+            result = await orchestrator._get_active_duplications(
+                Path("src/file.py"),
+                {"src/file.py": {180, 190}},  # lines inside the target block
+                diag,
+                project_key="temp-project",
+            )
+
+        assert len(result) == 1
+        assert result[0].from_line == 171
+        assert result[0].to_line == 205
+        assert len(result[0].other_locations) == 1
+        assert result[0].other_locations[0].file_path == "src/file.py"
+        assert result[0].other_locations[0].from_line == 249
+        assert result[0].other_locations[0].to_line == 283
+
 
 class TestGetResolvedDuplications:
     """Tests for ReviewOrchestrator._get_resolved_duplications()."""
@@ -935,3 +977,47 @@ class TestGetResolvedDuplications:
         assert passed_config.sonarqube_project_key == "main-project"
         # Orchestrator's own config must be untouched
         assert orchestrator.config.sonarqube_project_key == "temp-project"
+
+    @pytest.mark.asyncio
+    async def test_same_file_resolved_duplication_includes_other_locations(self, orchestrator) -> None:
+        """When both duplication blocks are in the same file (same _ref) on main,
+        the other block should still appear in other_locations for resolved dups."""
+        from vibe_heal.deduplication.models import DuplicationBlock, DuplicationGroup, DuplicationsResponse
+
+        # Both blocks share _ref="1" (same file)
+        target_block = DuplicationBlock(**{"from": 171, "size": 35, "_ref": "1"})
+        other_block = DuplicationBlock(**{"from": 249, "size": 35, "_ref": "1"})
+        group = DuplicationGroup(blocks=[target_block, other_block])
+
+        file_info = MagicMock()
+        file_info.key = "main-project:src/file.py"
+
+        response = MagicMock(spec=DuplicationsResponse)
+        response.duplications = [group]
+        response.get_target_file_ref.return_value = "1"
+        response.get_file_info.return_value = file_info
+
+        mock_dup_instance = AsyncMock()
+        mock_dup_instance.get_duplications_for_file.return_value = response
+
+        with patch("vibe_heal.review.orchestrator.DuplicationClient") as MockDupClient:
+            MockDupClient.return_value.__aenter__ = AsyncMock(return_value=mock_dup_instance)
+            MockDupClient.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            diag = self._make_diag()
+            result = await orchestrator._get_resolved_duplications(
+                Path("src/file.py"),
+                changed_lines_map={"src/file.py": {180}},  # new changed lines
+                old_changed_lines_map={"src/file.py": {180}},  # old lines inside block
+                active_dup_ranges=set(),  # not covered by active dups
+                original_project_key="main-project",
+                diag=diag,
+            )
+
+        assert len(result) == 1
+        assert result[0].main_from_line == 171
+        assert result[0].main_to_line == 205
+        assert len(result[0].other_locations) == 1
+        assert result[0].other_locations[0].file_path == "src/file.py"
+        assert result[0].other_locations[0].from_line == 249
+        assert result[0].other_locations[0].to_line == 283


### PR DESCRIPTION
The review command reported incomplete duplication information when both duplicate blocks existed within the same file. For example, a SonarQube duplications API response containing two blocks in src/hooks/workflow.ts (lines 171-205 and 249-283) would only report the anchor block with an empty other_locations list, resulting in GitHub PR comments like:

  Duplication detected (lines 171-205)
  This block is duplicated in:

The root cause was that _build_active_finding() and _resolve_group() used group.get_other_blocks(target_ref), which filters out all blocks sharing the same _ref value. Since same-file duplicates share the same _ref (e.g., both blocks have _ref: "1"), they were silently excluded.

The fix iterates over all group.blocks and skips only the specific target block instance by identity comparison (id()), rather than filtering by _ref. This correctly preserves same-file duplicates in the other_locations list.

- orchestrator.py: replace get_other_blocks(target_ref) with identity-based block skipping in both _build_active_finding() and _resolve_group()
- test_orchestrator.py: add two tests verifying same-file duplication blocks appear in other_locations for both active and resolved dups