### PR TITLE
feat(#120): resolve vibe-types URLs locally via git submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: actions/cache@v4
         with:
@@ -37,6 +39,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
@@ -61,6 +65,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/vibe-types"]
+	path = vendor/vibe-types
+	url = https://github.com/jpablo/vibe-types.git
+	branch = main

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -103,7 +103,7 @@ async def fetch_url_content(url: str) -> str | None:
         if local.exists():
             logger.debug("Reading vibe-types doc locally from %s", local)
             try:
-                return local.read_text()
+                return local.read_bytes()[:_MAX_DOC_BYTES].decode("utf-8", errors="replace")
             except OSError as e:
                 logger.debug("Failed to read local vibe-types file %s: %s", local, e)
         else:
@@ -120,13 +120,12 @@ async def fetch_url_content(url: str) -> str | None:
 
 async def fetch_external_rule_docs(message: str) -> list[str]:
     """Extract URLs from an issue message and return fetched content for each."""
-    urls = [u for u in extract_urls(message) if _is_safe_url(u)]
+    urls = extract_urls(message)
     if not urls:
         return []
     docs = []
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-        for url in urls:
-            content = await _stream_capped(url, client)
-            if content is not None:
-                docs.append(content)
+    for url in urls:
+        content = await fetch_url_content(url)
+        if content is not None:
+            docs.append(content)
     return docs

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -56,9 +56,19 @@ def _vibe_types_local_path(url: str) -> Path | None:
                 break
     if rel is None:
         return None
+    rel = rel.split("?")[0].split("#")[0]
+    rel_path = Path(rel)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        return None
     for parent in Path(__file__).resolve().parents:
         if (parent / ".git").exists():
-            return parent / "vendor" / "vibe-types" / rel
+            submodule_root = (parent / "vendor" / "vibe-types").resolve()
+            candidate = (submodule_root / rel_path).resolve()
+            try:
+                candidate.relative_to(submodule_root)
+            except ValueError:
+                return None
+            return candidate
     return None
 
 
@@ -92,11 +102,15 @@ async def fetch_url_content(url: str) -> str | None:
     if local is not None:
         if local.exists():
             logger.debug("Reading vibe-types doc locally from %s", local)
-            return local.read_text()
-        logger.debug("Local vibe-types path not found: %s (submodule not initialized?)", local)
-        # blob URLs return HTML over HTTP — convert to raw for the fallback
-        if url.startswith(_BLOB_PREFIX):
-            url = _RAW_PREFIXES[0] + url[len(_BLOB_PREFIX) :]
+            try:
+                return local.read_text()
+            except OSError as e:
+                logger.debug("Failed to read local vibe-types file %s: %s", local, e)
+        else:
+            logger.debug("Local vibe-types path not found: %s (submodule not initialized?)", local)
+    # blob URLs return HTML over HTTP — always convert to raw before fetching
+    if url.startswith(_BLOB_PREFIX):
+        url = _RAW_PREFIXES[0] + url[len(_BLOB_PREFIX) :]
     if not _is_safe_url(url):
         logger.debug("Blocked SSRF-risk URL: %s", url)
         return None

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -3,6 +3,7 @@
 import ipaddress
 import logging
 import re
+from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
@@ -36,6 +37,31 @@ def _is_safe_url(url: str) -> bool:
         return True  # hostname (not a bare IP) — allow through
 
 
+_BLOB_PREFIX = "https://github.com/jpablo/vibe-types/blob/main/"
+_RAW_PREFIXES = (
+    "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/",
+    "https://raw.githubusercontent.com/jpablo/vibe-types/main/",
+)
+
+
+def _vibe_types_local_path(url: str) -> Path | None:
+    """Map a vibe-types GitHub URL to its local submodule path, or None if not a vibe-types URL."""
+    rel: str | None = None
+    if url.startswith(_BLOB_PREFIX):
+        rel = url[len(_BLOB_PREFIX) :]
+    else:
+        for prefix in _RAW_PREFIXES:
+            if url.startswith(prefix):
+                rel = url[len(prefix) :]
+                break
+    if rel is None:
+        return None
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists():
+            return parent / "vendor" / "vibe-types" / rel
+    return None
+
+
 def extract_urls(text: str) -> list[str]:
     """Extract all HTTP/HTTPS URLs from a string, stripping trailing punctuation."""
     return [url.rstrip("".join(_TRAILING_PUNCTUATION)) for url in _URL_PATTERN.findall(text)]
@@ -62,6 +88,15 @@ async def _stream_capped(url: str, client: httpx.AsyncClient) -> str | None:
 
 async def fetch_url_content(url: str) -> str | None:
     """Fetch the text content of a URL, returning None on any error or SSRF-blocked host."""
+    local = _vibe_types_local_path(url)
+    if local is not None:
+        if local.exists():
+            logger.debug("Reading vibe-types doc locally from %s", local)
+            return local.read_text()
+        logger.debug("Local vibe-types path not found: %s (submodule not initialized?)", local)
+        # blob URLs return HTML over HTTP — convert to raw for the fallback
+        if url.startswith(_BLOB_PREFIX):
+            url = _RAW_PREFIXES[0] + url[len(_BLOB_PREFIX) :]
     if not _is_safe_url(url):
         logger.debug("Blocked SSRF-risk URL: %s", url)
         return None

--- a/tests/ai_tools/test_external_docs.py
+++ b/tests/ai_tools/test_external_docs.py
@@ -1,5 +1,8 @@
 """Tests for external_docs URL extraction and fetching."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import httpx
 import pytest
 import respx
@@ -7,6 +10,7 @@ import respx
 from vibe_heal.ai_tools.external_docs import (
     _MAX_DOC_BYTES,
     _is_safe_url,
+    _vibe_types_local_path,
     extract_urls,
     fetch_external_rule_docs,
     fetch_url_content,
@@ -59,6 +63,33 @@ class TestExtractUrls:
         assert extract_urls("") == []
 
 
+class TestVibeTypesLocalPath:
+    def test_raw_refs_heads_url(self) -> None:
+        url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
+        result = _vibe_types_local_path(url)
+        assert result is not None
+        assert result.parts[-3:] == ("vendor", "vibe-types", "plugin") or "vendor/vibe-types" in str(result)
+        assert str(result).endswith("plugin/skills/typescript/catalog/T01-algebraic-data-types.md")
+
+    def test_raw_main_url(self) -> None:
+        url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
+        result = _vibe_types_local_path(url)
+        assert result is not None
+        assert str(result).endswith("plugin/skills/typescript/catalog/T01-algebraic-data-types.md")
+
+    def test_blob_url(self) -> None:
+        url = "https://github.com/jpablo/vibe-types/blob/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
+        result = _vibe_types_local_path(url)
+        assert result is not None
+        assert str(result).endswith("plugin/skills/typescript/catalog/T01-algebraic-data-types.md")
+
+    def test_non_vibe_types_url_returns_none(self) -> None:
+        assert _vibe_types_local_path("https://example.com/doc.md") is None
+
+    def test_other_github_repo_returns_none(self) -> None:
+        assert _vibe_types_local_path("https://github.com/someother/repo/blob/main/file.md") is None
+
+
 class TestFetchUrlContent:
     @pytest.mark.asyncio
     @respx.mock
@@ -99,6 +130,31 @@ class TestFetchUrlContent:
         content = await fetch_url_content("https://example.com/large.md")
         assert content is not None
         assert len(content.encode("utf-8")) <= _MAX_DOC_BYTES
+
+    @pytest.mark.asyncio
+    async def test_vibe_types_url_reads_locally_when_file_exists(self, tmp_path: Path) -> None:
+        local_file = tmp_path / "T01.md"
+        local_file.write_text("# T01 local content")
+
+        url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=local_file):
+            content = await fetch_url_content(url)
+
+        assert content == "# T01 local content"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blob_url_falls_back_to_raw_when_no_submodule(self) -> None:
+        raw_url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
+        respx.get(raw_url).mock(return_value=httpx.Response(200, text="# fallback content"))
+
+        blob_url = "https://github.com/jpablo/vibe-types/blob/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
+        with patch(
+            "vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=Path("/nonexistent/path/T01.md")
+        ):
+            content = await fetch_url_content(blob_url)
+
+        assert content == "# fallback content"
 
 
 class TestFetchExternalRuleDocs:

--- a/tests/ai_tools/test_external_docs.py
+++ b/tests/ai_tools/test_external_docs.py
@@ -161,7 +161,7 @@ class TestFetchUrlContent:
 
         mock_path = MagicMock(spec=Path)
         mock_path.exists.return_value = True
-        mock_path.read_text.side_effect = OSError("permission denied")
+        mock_path.read_bytes.side_effect = OSError("permission denied")
 
         with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=mock_path):
             content = await fetch_url_content(raw_url)
@@ -194,6 +194,19 @@ class TestFetchUrlContent:
 
         assert content == "# fallback content"
 
+    @pytest.mark.asyncio
+    async def test_local_read_respects_max_doc_bytes(self, tmp_path: Path) -> None:
+        large_file = tmp_path / "large.md"
+        large_file.write_bytes(b"x" * (_MAX_DOC_BYTES + 1000))
+
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=large_file):
+            content = await fetch_url_content(
+                "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/large.md"
+            )
+
+        assert content is not None
+        assert len(content.encode("utf-8")) <= _MAX_DOC_BYTES
+
 
 class TestFetchExternalRuleDocs:
     @pytest.mark.asyncio
@@ -220,3 +233,14 @@ class TestFetchExternalRuleDocs:
     async def test_ssrf_url_in_message_is_skipped(self) -> None:
         docs = await fetch_external_rule_docs("See http://192.168.1.1/rule for details.")
         assert docs == []
+
+    @pytest.mark.asyncio
+    async def test_vibe_types_url_in_message_reads_locally(self, tmp_path: Path) -> None:
+        local_file = tmp_path / "T01.md"
+        local_file.write_text("# local doc content")
+
+        url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/T01.md"
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=local_file):
+            docs = await fetch_external_rule_docs(f"See {url} for details.")
+
+        assert docs == ["# local doc content"]

--- a/tests/ai_tools/test_external_docs.py
+++ b/tests/ai_tools/test_external_docs.py
@@ -1,7 +1,7 @@
 """Tests for external_docs URL extraction and fetching."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -68,8 +68,9 @@ class TestVibeTypesLocalPath:
         url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
         result = _vibe_types_local_path(url)
         assert result is not None
-        assert result.parts[-3:] == ("vendor", "vibe-types", "plugin") or "vendor/vibe-types" in str(result)
-        assert str(result).endswith("plugin/skills/typescript/catalog/T01-algebraic-data-types.md")
+        assert result.as_posix().endswith(
+            "vendor/vibe-types/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
+        )
 
     def test_raw_main_url(self) -> None:
         url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/plugin/skills/typescript/catalog/T01-algebraic-data-types.md"
@@ -88,6 +89,16 @@ class TestVibeTypesLocalPath:
 
     def test_other_github_repo_returns_none(self) -> None:
         assert _vibe_types_local_path("https://github.com/someother/repo/blob/main/file.md") is None
+
+    def test_path_traversal_returns_none(self) -> None:
+        url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/../../etc/passwd"
+        assert _vibe_types_local_path(url) is None
+
+    def test_url_with_query_string_strips_query(self) -> None:
+        url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/file.md?token=secret"
+        result = _vibe_types_local_path(url)
+        assert result is not None
+        assert result.as_posix().endswith("vendor/vibe-types/plugin/file.md")
 
 
 class TestFetchUrlContent:
@@ -141,6 +152,33 @@ class TestFetchUrlContent:
             content = await fetch_url_content(url)
 
         assert content == "# T01 local content"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_local_read_oserror_falls_back_to_http(self) -> None:
+        raw_url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/file.md"
+        respx.get(raw_url).mock(return_value=httpx.Response(200, text="# http content"))
+
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = True
+        mock_path.read_text.side_effect = OSError("permission denied")
+
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=mock_path):
+            content = await fetch_url_content(raw_url)
+
+        assert content == "# http content"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_blob_url_converts_to_raw_when_local_path_is_none(self) -> None:
+        raw_url = "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/plugin/file.md"
+        respx.get(raw_url).mock(return_value=httpx.Response(200, text="# raw content"))
+
+        blob_url = "https://github.com/jpablo/vibe-types/blob/main/plugin/file.md"
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=None):
+            content = await fetch_url_content(blob_url)
+
+        assert content == "# raw content"
 
     @pytest.mark.asyncio
     @respx.mock


### PR DESCRIPTION
Add jpablo/vibe-types as a submodule at vendor/vibe-types. When fetch_url_content encounters a vibe-types GitHub URL (blob or raw form), read the file directly from the submodule instead of making an HTTP request. Falls back to HTTP (converting blob URLs to raw first) if the submodule is not initialized. Update CI checkout steps to include submodules.

Fixes #120 