### PR TITLE
feat: include rule root_cause as collapsed section in GitHub output

### DIFF
--- a/src/vibe_heal/git/manager.py
+++ b/src/vibe_heal/git/manager.py
@@ -386,12 +386,15 @@ class GitManager:
 
         body_parts.append("")
 
-        # Add public documentation link
+        # Add public documentation link and collapsed root-cause explanation
         if rule:
             body_parts.extend([
                 f"Rationale: {rule.public_doc_url}",
                 "",
             ])
+            details = rule.as_details_block()
+            if details:
+                body_parts.extend([details, ""])
 
         body_parts.extend([
             f"Fixed by: vibe-heal using {ai_tool_type.display_name}",

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -129,6 +129,11 @@ class GitHubReviewClient:
                 body = f"**{issue.rule}** {issue.message}"
                 if issue.doc_url:
                     body += f"\n\n{issue.doc_url}"
+                if issue.root_cause:
+                    body += (
+                        f"\n\n<details>\n\n<summary>{issue.rule} — why this matters</summary>"
+                        f"\n\n{issue.root_cause}\n\n</details>"
+                    )
                 comments.append({
                     "path": file_review.file_path,
                     "line": issue.line,

--- a/src/vibe_heal/review/models.py
+++ b/src/vibe_heal/review/models.py
@@ -23,6 +23,10 @@ class ReviewIssue(BaseModel):
             "during filtering and no source_is_new_map is passed to filter_issues()."
         ),
     )
+    root_cause: str | None = Field(
+        default=None,
+        description="HTML content of the root_cause description section from SonarQube rule API",
+    )
 
 
 class DuplicationLocation(BaseModel):

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -209,7 +209,7 @@ class ReviewOrchestrator:
                 file_issues, diag = await self._get_filtered_issues(
                     file_path, changed_lines_map, verbose, project_key=temp_key
                 )
-                file_issues = await self._enrich_issues_with_descriptions(file_issues)
+                await self._enrich_issues_with_descriptions(file_issues)
                 active_dups = await self._get_active_duplications(
                     file_path, strict_new_lines_map, diag, project_key=temp_key
                 )
@@ -297,20 +297,17 @@ class ReviewOrchestrator:
             f"as review comments on PR #{pr}.[/green]"
         )
 
-    async def _enrich_issues_with_descriptions(self, issues: list[ReviewIssue]) -> list[ReviewIssue]:
+    async def _enrich_issues_with_descriptions(self, issues: list[ReviewIssue]) -> None:
         """Populate root_cause on each issue by fetching rule details from SonarQube.
 
-        Caches results per rule key for the lifetime of this orchestrator instance.
-        No-ops when config.include_rule_description is False.
+        Mutates issues in-place. Caches results per rule key for the lifetime of
+        this orchestrator instance. No-ops when config.include_rule_description is False.
 
         Args:
             issues: Issues to enrich in-place.
-
-        Returns:
-            The same list with root_cause populated where available.
         """
         if not self.config.include_rule_description:
-            return issues
+            return
 
         for issue in issues:
             if issue.rule not in self._rule_cache:
@@ -323,8 +320,6 @@ class ReviewOrchestrator:
             cached = self._rule_cache[issue.rule]
             if cached is not None:
                 issue.root_cause = cached.root_cause_html
-
-        return issues
 
     async def _create_temp_project(self) -> TempProjectMetadata:
         """Create temporary SonarQube project for analysis.

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -1,5 +1,6 @@
 """Review orchestration for analyzing SonarQube issues on changed lines."""
 
+import logging
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -28,10 +29,11 @@ from vibe_heal.review.reporter import (
 )
 from vibe_heal.sonarqube.analysis_runner import AnalysisRunner
 from vibe_heal.sonarqube.client import SonarQubeClient
-from vibe_heal.sonarqube.exceptions import ComponentNotFoundError, SonarQubeAPIError
+from vibe_heal.sonarqube.exceptions import ComponentNotFoundError, SonarQubeAPIError, SonarQubeError
 from vibe_heal.sonarqube.models import SonarQubeRule
 from vibe_heal.sonarqube.project_manager import ProjectManager, TempProjectMetadata
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 
@@ -314,7 +316,8 @@ class ReviewOrchestrator:
             if issue.rule not in self._rule_cache:
                 try:
                     self._rule_cache[issue.rule] = await self.client.get_rule_details(issue.rule)
-                except Exception:
+                except SonarQubeError as e:
+                    logger.warning("Could not fetch rule details for %s: %s", issue.rule, e)
                     self._rule_cache[issue.rule] = None
 
             cached = self._rule_cache[issue.rule]

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -29,6 +29,7 @@ from vibe_heal.review.reporter import (
 from vibe_heal.sonarqube.analysis_runner import AnalysisRunner
 from vibe_heal.sonarqube.client import SonarQubeClient
 from vibe_heal.sonarqube.exceptions import ComponentNotFoundError, SonarQubeAPIError
+from vibe_heal.sonarqube.models import SonarQubeRule
 from vibe_heal.sonarqube.project_manager import ProjectManager, TempProjectMetadata
 
 console = Console()
@@ -96,6 +97,7 @@ class ReviewOrchestrator:
         self.project_manager = ProjectManager(client)
         self.analysis_runner = AnalysisRunner(config, client)
         self.github_client = GitHubReviewClient()
+        self._rule_cache: dict[str, SonarQubeRule | None] = {}
 
     async def run_analysis(
         self,
@@ -205,6 +207,7 @@ class ReviewOrchestrator:
                 file_issues, diag = await self._get_filtered_issues(
                     file_path, changed_lines_map, verbose, project_key=temp_key
                 )
+                file_issues = await self._enrich_issues_with_descriptions(file_issues)
                 active_dups = await self._get_active_duplications(
                     file_path, strict_new_lines_map, diag, project_key=temp_key
                 )
@@ -291,6 +294,34 @@ class ReviewOrchestrator:
             f"{report.total_duplications} duplication finding(s) "
             f"as review comments on PR #{pr}.[/green]"
         )
+
+    async def _enrich_issues_with_descriptions(self, issues: list[ReviewIssue]) -> list[ReviewIssue]:
+        """Populate root_cause on each issue by fetching rule details from SonarQube.
+
+        Caches results per rule key for the lifetime of this orchestrator instance.
+        No-ops when config.include_rule_description is False.
+
+        Args:
+            issues: Issues to enrich in-place.
+
+        Returns:
+            The same list with root_cause populated where available.
+        """
+        if not self.config.include_rule_description:
+            return issues
+
+        for issue in issues:
+            if issue.rule not in self._rule_cache:
+                try:
+                    self._rule_cache[issue.rule] = await self.client.get_rule_details(issue.rule)
+                except Exception:
+                    self._rule_cache[issue.rule] = None
+
+            cached = self._rule_cache[issue.rule]
+            if cached is not None:
+                issue.root_cause = cached.root_cause_html
+
+        return issues
 
     async def _create_temp_project(self) -> TempProjectMetadata:
         """Create temporary SonarQube project for analysis.

--- a/src/vibe_heal/review/reporter.py
+++ b/src/vibe_heal/review/reporter.py
@@ -88,6 +88,26 @@ def _render_issues_table(issues: list[ReviewIssue]) -> list[str]:
     return lines
 
 
+def _render_rule_descriptions(issues: list[ReviewIssue]) -> list[str]:
+    """Render one collapsed <details> per unique rule that has a root_cause."""
+    lines: list[str] = []
+    seen: set[str] = set()
+    for issue in issues:
+        if issue.root_cause and issue.rule not in seen:
+            seen.add(issue.rule)
+            lines.extend([
+                "<details>",
+                "",
+                f"<summary>{issue.rule} — why this matters</summary>",
+                "",
+                issue.root_cause,
+                "",
+                "</details>",
+                "",
+            ])
+    return lines
+
+
 def _render_duplications(duplications: list[ReviewDuplication]) -> list[str]:
     """Render the active duplications section."""
     lines = ["### Active Duplications", "", "| Block (this file) | Duplicated in |", "|---|---|"]
@@ -122,6 +142,7 @@ def _render_file_section(fr: FileReview, base_branch: str = "main") -> list[str]
 
     if fr.issues:
         lines.extend(_render_issues_table(fr.issues))
+        lines.extend(_render_rule_descriptions(fr.issues))
 
     if fr.duplications:
         lines.extend(_render_duplications(fr.duplications))

--- a/src/vibe_heal/sonarqube/models.py
+++ b/src/vibe_heal/sonarqube/models.py
@@ -212,6 +212,29 @@ class SonarQubeRule(BaseModel):
         return text.strip()
 
     @property
+    def root_cause_html(self) -> str | None:
+        """Get the HTML content of the root_cause description section."""
+        for section in self.description_sections:
+            if section.key == "root_cause":
+                return section.content
+        return None
+
+    def as_details_block(self, summary_label: str | None = None) -> str | None:
+        """Format root_cause as a GitHub collapsed <details> section.
+
+        Args:
+            summary_label: Text for the <summary> tag. Defaults to "Why: {rule name}".
+
+        Returns:
+            Formatted <details> block, or None if no root_cause section exists.
+        """
+        html = self.root_cause_html
+        if not html:
+            return None
+        label = summary_label or f"Why: {self.name}"
+        return f"<details>\n\n<summary>{label}</summary>\n\n{html}\n\n</details>"
+
+    @property
     def public_doc_url(self) -> str:
         """Generate URL for public SonarSource rule documentation.
 

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -313,6 +313,7 @@ class TestRunAnalysis:
             ) as mock_delete,
             patch.object(orchestrator, "_get_active_duplications", new_callable=AsyncMock, return_value=[]),
             patch.object(orchestrator, "_get_resolved_duplications", new_callable=AsyncMock, return_value=[]),
+            patch.object(orchestrator.client, "get_rule_details", AsyncMock(return_value=None)),
         ):
             result = await orchestrator.run_analysis(
                 base_branch="origin/main",
@@ -465,6 +466,7 @@ class TestRunAnalysis:
             ),
             patch.object(orchestrator, "_get_active_duplications", new_callable=AsyncMock, return_value=[]),
             patch.object(orchestrator, "_get_resolved_duplications", new_callable=AsyncMock, return_value=[]),
+            patch.object(orchestrator.client, "get_rule_details", AsyncMock(return_value=None)),
         ):
             report_path = tmp_path / "reports" / "review.json"
             result = await orchestrator.run_analysis(

--- a/tests/review/test_reporter.py
+++ b/tests/review/test_reporter.py
@@ -151,3 +151,53 @@ class TestWriteReports:
         assert (custom_dir / "review.md").exists()
         loaded = load_report(custom_dir)
         assert loaded.total_issues == 3
+
+    def test_markdown_rule_descriptions_collapsed_section(self, tmp_path: Path) -> None:
+        """root_cause on ReviewIssue renders as one <details> block per unique rule."""
+        result = ReviewResult(
+            project_key="my-project",
+            branch="feature/test",
+            base_branch="origin/main",
+            files=[
+                FileReview(
+                    file_path="src/example.py",
+                    issues=[
+                        ReviewIssue(
+                            rule="python:S1481",
+                            message="Remove unused variable",
+                            line=10,
+                            severity="MAJOR",
+                            root_cause="<p>Unused variables clutter code.</p>",
+                        ),
+                        # Same rule — should produce only one <details> block
+                        ReviewIssue(
+                            rule="python:S1481",
+                            message="Another unused variable",
+                            line=20,
+                            severity="MAJOR",
+                            root_cause="<p>Unused variables clutter code.</p>",
+                        ),
+                        # Different rule — should produce a second <details> block
+                        ReviewIssue(
+                            rule="python:S1192",
+                            message="Define a constant",
+                            line=30,
+                            severity="MINOR",
+                            root_cause="<p>Magic numbers reduce readability.</p>",
+                        ),
+                        # No root_cause — should produce no <details> block
+                        ReviewIssue(rule="python:S999", message="Other issue", line=40, severity="INFO"),
+                    ],
+                )
+            ],
+        )
+        write_reports(result, tmp_path)
+        md = (tmp_path / "review.md").read_text()
+
+        assert md.count("<details>") == 2
+        assert md.count("</details>") == 2
+        assert "python:S1481 — why this matters" in md
+        assert "python:S1192 — why this matters" in md
+        assert "<p>Unused variables clutter code.</p>" in md
+        assert "<p>Magic numbers reduce readability.</p>" in md
+        assert "python:S999" not in md.split("<details>")[1] if "<details>" in md else True


### PR DESCRIPTION
## Summary

- SonarQube's public rule links no longer display the rule explanation inline, leaving commit messages and PR comments without useful context
- Adds the `root_cause` description section from the SonarQube rule API as a GitHub `<details>` collapsed block across all relevant outputs: commit messages (`fix`/`cleanup`), review markdown reports, and GitHub PR inline comments
- `ReviewIssue` now persists `root_cause` in `review.json` so `review post` can include descriptions without re-fetching; rule lookups are cached per-session to avoid redundant API calls when the same rule appears across multiple files

## Test plan

- [ ] Run `vibe-heal fix <file>` and confirm commit message body contains a `<details>` block with `Why: <rule name>` summary when `INCLUDE_RULE_DESCRIPTION=true`
- [ ] Run `vibe-heal review` and confirm the generated `review.md` shows a collapsed section per unique rule beneath each file's issues table
- [ ] Run `vibe-heal review post` and confirm inline PR comments include the `<details>` block
- [ ] Set `INCLUDE_RULE_DESCRIPTION=false` and confirm no `<details>` blocks appear in any output
- [ ] Confirm `vibe-heal dedupe` and `vibe-heal dedupe-branch` are unaffected (no rule description fetched)
- [ ] All 505 tests pass: `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)