### PR TITLE
feat: add --coverage flag to vibe-heal review

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ vibe-heal integrates with SonarQube to automatically fix code quality issues usi
 
 - **Branch cleanup**: Automatically fix all modified files in a branch before code review
 - **Code deduplication**: AI-powered removal of duplicate code blocks
-- **Branch review**: Report SonarQube issues scoped to changed lines and post inline GitHub PR comments
+- **Branch review**: Report SonarQube issues scoped to changed lines, optionally include test coverage metrics, and post inline GitHub PR comments
 - **`sonar-project.properties` support**: Honors your existing scanner configuration file — only adds missing auth or host flags, and temporarily patches the project key/name for temp-project runs
 - Fetch SonarQube issues for any file
 - AI-powered issue fixing with **Claude Code** or **Aider**
@@ -174,6 +174,9 @@ vibe-heal review --base-branch origin/develop
 
 # Limit to specific file patterns
 vibe-heal review --pattern "*.py"
+
+# Include test coverage for changed lines (requires coverage data in SonarQube)
+vibe-heal review --coverage
 
 # Post the saved report as inline GitHub PR comments
 vibe-heal review --post

--- a/docs/review-guide.md
+++ b/docs/review-guide.md
@@ -223,7 +223,7 @@ Coverage data must be present in SonarQube. This typically means:
 1. Running your test suite with a coverage tool (e.g. `pytest --cov`, `jest --coverage`, `jacoco`) and generating a coverage report.
 2. Passing the coverage report path to `sonar-scanner` (e.g. `sonar.python.coverage.reportPaths=coverage.xml`) before vibe-heal runs its analysis.
 
-If SonarQube has no coverage data for a file, `--coverage` silently omits that file from coverage output (no error, no column entry). With `--verbose`, a note is printed: `no coverage data (run tests before sonar-scanner)`.
+If SonarQube has no coverage data for a file, `--coverage` shows `—` for that file when the Coverage column is present, and omits the file from the Coverage section in PR/Markdown output. With `--verbose`, a note is printed: `no coverage data available`.
 
 ### Example
 

--- a/docs/review-guide.md
+++ b/docs/review-guide.md
@@ -78,6 +78,9 @@ vibe-heal review --base-branch origin/develop
 # Limit to specific file patterns
 vibe-heal review --pattern "src/**/*.py"
 
+# Include test coverage for changed lines (requires coverage data in SonarQube)
+vibe-heal review --coverage
+
 # Save report to a custom path
 vibe-heal review --report-file /tmp/my-review.json
 ```
@@ -107,6 +110,7 @@ vibe-heal review --post --report-file /tmp/my-review.json
 | `--report-file` | auto | Override report output path |
 | `--env-file` | `.env.vibeheal` | Path to custom config file |
 | `--verbose` / `-v` | off | Enable debug logging |
+| `--coverage` | off | Report test coverage for changed lines (requires coverage data in SonarQube) |
 | `--post` | off | Post saved report to GitHub PR instead of analyzing |
 | `--dry-run` | off | With `--post`: preview comments without API calls |
 | `--pr` | auto | With `--post`: explicit GitHub PR number |
@@ -126,10 +130,12 @@ vibe-heal review --post --report-file /tmp/my-review.json
 8. Detect resolved duplications: blocks that existed on the base branch but
    are no longer active — warns if only one copy was deduplicated
 9. Optionally enrich each issue with rule root_cause documentation
-10. Write report to ~/.vibe-heal/reviews/<project-key>/<branch>/review.json
+10. If --coverage: fetch lineHits data per changed line from SonarQube and
+    compute coverage_pct/covered_lines/instrumented_changed_lines per file
+11. Write report to ~/.vibe-heal/reviews/<project-key>/<branch>/review.json
     and review.md
-11. Delete temporary SonarQube project
-12. Display per-file summary table in terminal
+12. Delete temporary SonarQube project
+13. Display per-file summary table in terminal (with Coverage column when applicable)
 ```
 
 ### Post phase
@@ -147,6 +153,7 @@ The two phases are decoupled — you can run `review` in CI and `review --post` 
 
 ### Terminal output (analyze phase)
 
+Without `--coverage`:
 ```
 Review Summary:
   Branch: feature/new-api (base: origin/main)
@@ -164,12 +171,24 @@ Per-File Breakdown:
 Report saved to /Users/you/.vibe-heal/reviews/my-project/feature-new-api/review.json
 ```
 
+With `--coverage` (adds a Coverage column when SonarQube has coverage data):
+```
+Per-File Breakdown:
+  File                      Issues  Highest Severity  Duplications  Coverage
+  src/api/users.py               3          CRITICAL             0     66.7%
+  src/api/auth.py                2             MAJOR             1     50.0%
+  src/models/user.py             2             MINOR             0      100%
+  tests/test_api.py              0               N/A             0        —
+```
+
+The Coverage column shows the percentage of **instrumented changed lines** (lines SonarQube has hit-count data for) that were covered by at least one test. Lines with no instrumentation data (e.g. comments, blank lines, or files not processed by the coverage tool) are excluded from the calculation. `—` means no coverage data was available for that file.
+
 ### Report files
 
 Two files are written after each analysis:
 
-- **`review.json`** — machine-readable report; includes `root_cause` HTML per issue so `--post` can include rule docs without re-fetching.
-- **`review.md`** — human-readable Markdown with issues per file and one collapsed `<details>` block per unique rule (deduped).
+- **`review.json`** — machine-readable report; includes `root_cause` HTML per issue so `--post` can include rule docs without re-fetching. Also stores `coverage_pct`, `covered_lines`, and `instrumented_changed_lines` per file when `--coverage` was used.
+- **`review.md`** — human-readable Markdown with issues per file and one collapsed `<details>` block per unique rule (deduped). When coverage data is present, each file section opens with a bold coverage line (e.g. `**Coverage on changed lines: 66.7% (4/6 instrumented lines covered)**`).
 
 Default report directory: `~/.vibe-heal/reviews/<project-key>/<branch>/`
 
@@ -184,6 +203,37 @@ Each issue becomes an inline comment anchored to the relevant line. Comments inc
 Duplication findings appear as comments noting the other locations where the same code exists.
 
 Resolved duplications (code that was duplicated on the base branch but is no longer duplicated in your branch — possibly meaning you fixed only one copy) appear with a warning to check the remaining copies.
+
+When the report contains coverage data (i.e. `review` was run with `--coverage`), the PR review body includes a **Coverage on changed lines** section listing each file's coverage percentage and instrumented line counts.
+
+## Coverage Reporting
+
+When `--coverage` is passed, vibe-heal fetches SonarQube's `lineHits` data for each changed file and computes coverage metrics scoped to the lines you actually changed.
+
+### What is counted
+
+- **Instrumented line** — a changed line for which SonarQube has hit-count data (i.e. the line was processed by the coverage tool during test execution). Comments, blank lines, and lines outside the coverage tool's scope are not instrumented.
+- **Covered line** — an instrumented line with `lineHits > 0` (executed at least once during testing).
+- **`coverage_pct`** — `covered_lines / instrumented_changed_lines × 100`, rounded to one decimal place.
+
+### Prerequisites
+
+Coverage data must be present in SonarQube. This typically means:
+
+1. Running your test suite with a coverage tool (e.g. `pytest --cov`, `jest --coverage`, `jacoco`) and generating a coverage report.
+2. Passing the coverage report path to `sonar-scanner` (e.g. `sonar.python.coverage.reportPaths=coverage.xml`) before vibe-heal runs its analysis.
+
+If SonarQube has no coverage data for a file, `--coverage` silently omits that file from coverage output (no error, no column entry). With `--verbose`, a note is printed: `no coverage data (run tests before sonar-scanner)`.
+
+### Example
+
+```bash
+# Run tests and generate coverage first
+uv run pytest --cov --cov-report=xml
+
+# Then review with coverage
+vibe-heal review --coverage
+```
 
 ## Duplication Findings
 
@@ -332,6 +382,14 @@ vibe-heal review --post --report-file /tmp/review.json
 ### "sonar-scanner is not installed or not in PATH"
 
 See the [Branch Cleanup Guide troubleshooting section](branch-cleanup-guide.md#issue-sonar-scanner-is-not-installed-or-not-in-path) for installation instructions.
+
+### Coverage column not shown despite using `--coverage`
+
+Coverage data must be uploaded to SonarQube before running `vibe-heal review`. Make sure you:
+
+1. Run your test suite with coverage enabled and generate a report (e.g. `coverage.xml`).
+2. Verify that your `sonar-project.properties` or `sonar-scanner` flags include the coverage report path (e.g. `sonar.python.coverage.reportPaths=coverage.xml`).
+3. Run `vibe-heal review --coverage --verbose` — if coverage is missing, vibe-heal prints `no coverage data (run tests before sonar-scanner)` for each affected file.
 
 ### No issues reported despite known violations
 

--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -584,6 +584,9 @@ def _display_review_results(result: ReviewAnalysisResult) -> None:
         table.add_column("Issues", justify="right")
         table.add_column("Highest Severity", justify="right")
         table.add_column("Duplications", justify="right")
+        show_coverage = any(f.coverage_pct is not None for f in result.files)
+        if show_coverage:
+            table.add_column("Coverage", justify="right")
 
         severity_order = ["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]
 
@@ -597,7 +600,11 @@ def _display_review_results(result: ReviewAnalysisResult) -> None:
                 )
             else:
                 highest_severity = "N/A"
-            table.add_row(file_review.file_path, str(issue_count), highest_severity, str(dup_count))
+            row: list[str] = [file_review.file_path, str(issue_count), highest_severity, str(dup_count)]
+            if show_coverage:
+                cov_str = f"{file_review.coverage_pct}%" if file_review.coverage_pct is not None else "—"
+                row.append(cov_str)
+            table.add_row(*row)
 
         console.print(table)
     elif total_issues == 0 and total_duplications == 0:
@@ -613,6 +620,7 @@ async def _run_review(
     file_patterns: list[str] | None,
     report_file: Path | None,
     verbose: bool,
+    coverage: bool = False,
 ) -> None:
     """Run review analysis workflow.
 
@@ -622,6 +630,7 @@ async def _run_review(
         file_patterns: Optional file patterns to filter.
         report_file: Optional path override for the report; None uses the default.
         verbose: Enable verbose output.
+        coverage: When True, fetch and display line coverage for changed lines.
     """
     async with SonarQubeClient(config) as client:
         orchestrator = ReviewOrchestrator(config, client)
@@ -630,6 +639,7 @@ async def _run_review(
             file_patterns=file_patterns,
             report_file=report_file,
             verbose=verbose,
+            coverage=coverage,
         )
         _display_review_results(result)
         if not result.success:
@@ -792,6 +802,7 @@ def review(
         "-v",
         help=VERBOSE_OUTPUT_HELP,
     ),
+    coverage: bool = typer.Option(False, "--coverage", help="Report test coverage for changed lines."),
 ) -> None:
     """Analyze SonarQube issues on changed lines.
 
@@ -816,6 +827,7 @@ def review(
                 file_patterns=file_patterns,
                 report_file=report_file,
                 verbose=verbose,
+                coverage=coverage,
             )
         )
 

--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -22,6 +22,7 @@ from vibe_heal.deduplication.orchestrator import (
 )
 from vibe_heal.orchestrator import VibeHealOrchestrator
 from vibe_heal.review import NoOpenPrError, ReviewOrchestrator
+from vibe_heal.review.models import ReviewIssue
 from vibe_heal.review.orchestrator import ReviewAnalysisResult
 from vibe_heal.review.reporter import default_report_dir
 from vibe_heal.sonarqube.client import SonarQubeClient
@@ -561,6 +562,51 @@ def dedupe_branch(
         sys.exit(1)
 
 
+_SEVERITY_ORDER = ["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]
+
+
+def _get_highest_severity(
+    issues: list[ReviewIssue],
+    severity_order: list[str] | None = None,
+) -> str:
+    """Return the highest severity string for a list of issues."""
+    if not issues:
+        return "N/A"
+    order = severity_order or _SEVERITY_ORDER
+    return min(
+        (issue.severity for issue in issues),
+        key=lambda s: order.index(s) if s in order else len(order),
+    )
+
+
+def _build_review_table(result: ReviewAnalysisResult) -> None:
+    """Build and print the per-file breakdown table for review results."""
+    if not result.files:
+        return
+
+    console.print("\n[bold]Per-File Breakdown:[/bold]")
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("File", style="cyan")
+    table.add_column("Issues", justify="right")
+    table.add_column("Highest Severity", justify="right")
+    table.add_column("Duplications", justify="right")
+    show_coverage = any(f.coverage_pct is not None for f in result.files)
+    if show_coverage:
+        table.add_column("Coverage", justify="right")
+
+    for file_review in result.files:
+        issue_count = len(file_review.issues)
+        dup_count = len(file_review.duplications) + len(file_review.resolved_duplications)
+        highest_severity = _get_highest_severity(file_review.issues)
+        row: list[str] = [file_review.file_path, str(issue_count), highest_severity, str(dup_count)]
+        if show_coverage:
+            cov_str = f"{file_review.coverage_pct}%" if file_review.coverage_pct is not None else "—"
+            row.append(cov_str)
+        table.add_row(*row)
+
+    console.print(table)
+
+
 def _display_review_results(result: ReviewAnalysisResult) -> None:
     """Display review analysis results.
 
@@ -578,35 +624,7 @@ def _display_review_results(result: ReviewAnalysisResult) -> None:
     console.print(f"  [green]Duplication findings: {total_duplications}[/green]")
 
     if result.files:
-        console.print("\n[bold]Per-File Breakdown:[/bold]")
-        table = Table(show_header=True, header_style="bold")
-        table.add_column("File", style="cyan")
-        table.add_column("Issues", justify="right")
-        table.add_column("Highest Severity", justify="right")
-        table.add_column("Duplications", justify="right")
-        show_coverage = any(f.coverage_pct is not None for f in result.files)
-        if show_coverage:
-            table.add_column("Coverage", justify="right")
-
-        severity_order = ["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]
-
-        for file_review in result.files:
-            issue_count = len(file_review.issues)
-            dup_count = len(file_review.duplications) + len(file_review.resolved_duplications)
-            if issue_count > 0:
-                highest_severity = min(
-                    (issue.severity for issue in file_review.issues),
-                    key=lambda s: severity_order.index(s) if s in severity_order else len(severity_order),
-                )
-            else:
-                highest_severity = "N/A"
-            row: list[str] = [file_review.file_path, str(issue_count), highest_severity, str(dup_count)]
-            if show_coverage:
-                cov_str = f"{file_review.coverage_pct}%" if file_review.coverage_pct is not None else "—"
-                row.append(cov_str)
-            table.add_row(*row)
-
-        console.print(table)
+        _build_review_table(result)
     elif total_issues == 0 and total_duplications == 0:
         console.print("\n[green]No issues found on changed lines.[/green]")
 

--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -572,7 +572,7 @@ def _get_highest_severity(
     """Return the highest severity string for a list of issues."""
     if not issues:
         return "N/A"
-    order = severity_order or _SEVERITY_ORDER
+    order = _SEVERITY_ORDER if severity_order is None else severity_order
     return min(
         (issue.severity for issue in issues),
         key=lambda s: order.index(s) if s in order else len(order),

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -255,14 +255,12 @@ class GitHubReviewClient:
         self,
         cmd: list[str],
         payload: dict[str, Any],
-        timeout: int = 60,
     ) -> None:
         """Post JSON data to a gh API endpoint via stdin.
 
         Args:
             cmd: Command to run (must accept JSON on stdin).
             payload: JSON-serialisable payload to send.
-            timeout: Timeout in seconds (default 60).
 
         Raises:
             GitHubReviewError: If the command fails or times out.
@@ -275,14 +273,12 @@ class GitHubReviewClient:
             stderr=asyncio.subprocess.PIPE,
         )
         try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(stdin_data),
-                timeout=timeout,
-            )
+            async with asyncio.timeout(60):
+                stdout_bytes, stderr_bytes = await process.communicate(stdin_data)
         except asyncio.TimeoutError:
             process.kill()
             await process.wait()
-            raise GitHubReviewError(f"gh API call timed out after {timeout}s") from None
+            raise GitHubReviewError("gh API call timed out after 60s") from None
         if process.returncode != 0:
             stderr_msg = stderr_bytes.decode().strip()
             stdout_msg = stdout_bytes.decode().strip()

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -35,7 +35,7 @@ class GitHubReviewClient:
         """
         try:
             result = await run_command(["gh", "--version"], timeout=10)
-        except (FileNotFoundError, OSError) as exc:
+        except OSError as exc:
             msg = "gh CLI is not installed or not in PATH. Install it from https://cli.github.com/"
             raise OSError(msg) from exc
         if not result.success:

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -156,6 +156,13 @@ class GitHubReviewClient:
                 "**Issues near changed lines** (outside diff — shown here instead of inline):\n"
                 + "\n".join(nearby_lines)
             )
+        coverage_lines = [
+            f"- `{fr.file_path}`: {fr.coverage_pct}% ({fr.covered_lines}/{fr.instrumented_changed_lines} instrumented lines covered)"
+            for fr in report.files
+            if fr.coverage_pct is not None
+        ]
+        if coverage_lines:
+            body_parts.append("**Coverage on changed lines:**\n" + "\n".join(coverage_lines))
         return {"event": "COMMENT", "body": "\n\n".join(body_parts), "comments": comments}
 
     def _build_issue_body(self, issue: ReviewIssue) -> str:
@@ -229,6 +236,15 @@ class GitHubReviewClient:
                     f"lines {res.main_from_line}-{res.main_to_line} in main were duplicated; "
                     f"{len(res.other_locations)} other instance(s) may need updating",
                 )
+        coverage_lines = [
+            f"- `{fr.file_path}`: {fr.coverage_pct}% ({fr.covered_lines}/{fr.instrumented_changed_lines} instrumented lines covered)"
+            for fr in report.files
+            if fr.coverage_pct is not None
+        ]
+        if coverage_lines:
+            lines.append("")
+            lines.append("**Coverage on changed lines:**")
+            lines.extend(coverage_lines)
         return {
             "event": "COMMENT",
             "body": "\n".join(lines),

--- a/src/vibe_heal/review/models.py
+++ b/src/vibe_heal/review/models.py
@@ -97,6 +97,14 @@ class FileReview(BaseModel):
         default_factory=list,
         description="Blocks duplicated in main that were modified; other instances may need updating",
     )
+    coverage_pct: float | None = Field(
+        default=None,
+        description="Percentage of instrumented changed lines covered by tests.",
+    )
+    covered_lines: int = Field(default=0, description="Instrumented changed lines that were covered.")
+    instrumented_changed_lines: int = Field(
+        default=0, description="Changed lines that could be covered (lineHits not None)."
+    )
 
 
 class FileDiagnostics(BaseModel):

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -677,6 +677,8 @@ class ReviewOrchestrator:
         if not coverage:
             return None, 0, 0
         changed_lines_for_file = changed_lines_map.get(repo_relative, set())
+        if not changed_lines_for_file:
+            return None, 0, 0
         try:
             cov = await self.client.get_line_coverage(repo_relative, changed_lines_for_file, project_key=project_key)
         except Exception as exc:
@@ -686,7 +688,7 @@ class ReviewOrchestrator:
             covered_lines, instrumented_changed_lines = cov
             return round(covered_lines / instrumented_changed_lines * 100, 1), covered_lines, instrumented_changed_lines
         if verbose:
-            console.print(f"[dim]  {repo_relative}: no coverage data (run tests before sonar-scanner)[/dim]")
+            console.print(f"[dim]  {repo_relative}: no coverage data available[/dim]")
         return None, 0, 0
 
     async def _cleanup_temp_project(self, temp_project: TempProjectMetadata | None) -> None:

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -112,6 +112,7 @@ class ReviewOrchestrator:
         file_patterns: list[str] | None = None,
         report_file: Path | None = None,
         verbose: bool = False,
+        coverage: bool = False,
     ) -> ReviewAnalysisResult:
         """Analyze SonarQube issues on changed lines.
 
@@ -131,6 +132,10 @@ class ReviewOrchestrator:
             report_file: Optional path to write the report JSON to.
                 If provided, the parent directory is used for report output.
             verbose: Enable verbose output.
+            coverage: When True, fetch line coverage data for changed lines and
+                populate coverage_pct/covered_lines/instrumented_changed_lines on
+                each FileReview. Files with coverage data are included even if they
+                have no issues or duplications.
 
         Returns:
             ReviewAnalysisResult with success status and review data.
@@ -226,14 +231,20 @@ class ReviewOrchestrator:
                 resolved_dups = await self._get_resolved_duplications(
                     file_path, changed_lines_map, old_changed_lines_map, active_ranges, original_project_key, diag
                 )
+                coverage_pct, covered_lines, instrumented_changed_lines = await self._fetch_coverage(
+                    repo_relative, changed_lines_map, temp_key, coverage, verbose
+                )
                 result.diagnostics.append(diag)
-                if file_issues or active_dups or resolved_dups:
+                if file_issues or active_dups or resolved_dups or coverage_pct is not None:
                     result.files.append(
                         FileReview(
                             file_path=repo_relative,
                             issues=file_issues,
                             duplications=active_dups,
                             resolved_duplications=resolved_dups,
+                            coverage_pct=coverage_pct,
+                            covered_lines=covered_lines,
+                            instrumented_changed_lines=instrumented_changed_lines,
                         )
                     )
                 elif verbose:
@@ -641,6 +652,42 @@ class ReviewOrchestrator:
             other_locations=other_locations,
             anchor_new_line=anchor_new_line,
         )
+
+    async def _fetch_coverage(
+        self,
+        repo_relative: str,
+        changed_lines_map: dict[str, set[int]],
+        project_key: str,
+        coverage: bool,
+        verbose: bool,
+    ) -> tuple[float | None, int, int]:
+        """Fetch line coverage for a file's changed lines from the temp project.
+
+        Args:
+            repo_relative: Repo-root-relative POSIX path to the file.
+            changed_lines_map: Mapping of file paths to changed line sets.
+            project_key: Temporary SonarQube project key.
+            coverage: When False, returns (None, 0, 0) immediately without any API call.
+            verbose: Enable verbose output.
+
+        Returns:
+            Tuple of (coverage_pct, covered_lines, instrumented_changed_lines).
+            coverage_pct is None when coverage is False, data is unavailable, or fetch fails.
+        """
+        if not coverage:
+            return None, 0, 0
+        changed_lines_for_file = changed_lines_map.get(repo_relative, set())
+        try:
+            cov = await self.client.get_line_coverage(repo_relative, changed_lines_for_file, project_key=project_key)
+        except Exception as exc:
+            console.print(f"[yellow]  {repo_relative}: coverage fetch failed: {exc}[/yellow]")
+            cov = None
+        if cov is not None:
+            covered_lines, instrumented_changed_lines = cov
+            return round(covered_lines / instrumented_changed_lines * 100, 1), covered_lines, instrumented_changed_lines
+        if verbose:
+            console.print(f"[dim]  {repo_relative}: no coverage data (run tests before sonar-scanner)[/dim]")
+        return None, 0, 0
 
     async def _cleanup_temp_project(self, temp_project: TempProjectMetadata | None) -> None:
         """Clean up temporary SonarQube project.

--- a/src/vibe_heal/review/reporter.py
+++ b/src/vibe_heal/review/reporter.py
@@ -140,6 +140,13 @@ def _render_file_section(fr: FileReview, base_branch: str = "main") -> list[str]
     """Render a single file's review section."""
     lines = [f"## `{fr.file_path}`", ""]
 
+    if fr.coverage_pct is not None:
+        lines.append(
+            f"**Coverage on changed lines: {fr.coverage_pct}%"
+            f" ({fr.covered_lines}/{fr.instrumented_changed_lines} instrumented lines covered)**"
+        )
+        lines.append("")
+
     if fr.issues:
         lines.extend(_render_issues_table(fr.issues))
         lines.extend(_render_rule_descriptions(fr.issues))
@@ -150,7 +157,7 @@ def _render_file_section(fr: FileReview, base_branch: str = "main") -> list[str]
     if fr.resolved_duplications:
         lines.extend(_render_resolved_duplications(fr.resolved_duplications, base_branch))
 
-    if not fr.issues and not fr.duplications and not fr.resolved_duplications:
+    if not fr.issues and not fr.duplications and not fr.resolved_duplications and fr.coverage_pct is None:
         lines.extend(["No issues.", ""])
 
     return lines

--- a/src/vibe_heal/sonarqube/client.py
+++ b/src/vibe_heal/sonarqube/client.py
@@ -289,6 +289,7 @@ class SonarQubeClient:
         file_path: str,
         from_line: int | None = None,
         to_line: int | None = None,
+        project_key: str | None = None,
     ) -> list[SourceLine]:
         """Get source code lines for a specific file.
 
@@ -296,6 +297,7 @@ class SonarQubeClient:
             file_path: Path to the file (relative to project root)
             from_line: Start line number (1-based, inclusive). If None, starts from line 1
             to_line: End line number (1-based, inclusive). If None, gets all lines
+            project_key: SonarQube project key. If None, uses the configured project key
 
         Returns:
             List of source code lines
@@ -305,7 +307,8 @@ class SonarQubeClient:
             SonarQubeAPIError: API request failed
         """
         # Build component identifier: projectKey:filePath
-        component = f"{self.config.sonarqube_project_key}:{file_path}"
+        effective_key = project_key if project_key is not None else self.config.sonarqube_project_key
+        component = f"{effective_key}:{file_path}"
 
         params: dict[str, Any] = {
             "key": component,

--- a/src/vibe_heal/sonarqube/client.py
+++ b/src/vibe_heal/sonarqube/client.py
@@ -324,6 +324,44 @@ class SonarQubeClient:
 
         return response.sources
 
+    async def get_line_coverage(
+        self,
+        file_path: str,
+        changed_lines: set[int],
+        project_key: str | None = None,
+    ) -> tuple[int, int] | None:
+        """Return (covered_lines, instrumented_changed_lines) for the given changed lines.
+
+        A line is instrumented if lineHits is not None (i.e. SonarQube has coverage data for it).
+        A line is covered if lineHits > 0.
+        Returns None if changed_lines is empty, the component is not found, or no changed
+        line is instrumented. Any exception other than ComponentNotFoundError propagates to the caller.
+
+        Args:
+            file_path: Path to the file (relative to project root)
+            changed_lines: Set of line numbers to check coverage for
+            project_key: SonarQube project key. If None, uses the configured project key
+
+        Returns:
+            Tuple of (covered_lines, instrumented_changed_lines), or None
+        """
+        if not changed_lines:
+            return None
+        try:
+            source_lines = await self.get_source_lines(
+                file_path,
+                from_line=min(changed_lines),
+                to_line=max(changed_lines),
+                project_key=project_key,
+            )
+        except ComponentNotFoundError:
+            return None
+        instrumented = [ln for ln in source_lines if ln.line in changed_lines and ln.line_hits is not None]
+        if not instrumented:
+            return None
+        covered = sum(1 for ln in instrumented if (ln.line_hits or 0) > 0)
+        return (covered, len(instrumented))
+
     async def create_project(self, key: str, name: str) -> None:
         """Create a new SonarQube project.
 

--- a/src/vibe_heal/sonarqube/models.py
+++ b/src/vibe_heal/sonarqube/models.py
@@ -284,6 +284,11 @@ class SourceLine(BaseModel):
         alias="isNew",
         description="Whether line is new code",
     )
+    line_hits: int | None = Field(
+        default=None,
+        alias="lineHits",
+        description="Times this line was executed by tests. None = not instrumented.",
+    )
 
     @property
     def plain_code(self) -> str:

--- a/tests/review/test_github.py
+++ b/tests/review/test_github.py
@@ -535,3 +535,34 @@ class TestPostReview:
         paths = {c["path"] for c in stdin_json["comments"]}
         assert "src/a.py" in paths
         assert "src/b.py" in paths
+
+
+class TestBuildPayloadCoverage:
+    def _make_report(self, **file_kwargs) -> ReviewResult:
+        return ReviewResult(
+            project_key="p",
+            branch="feature/x",
+            base_branch="origin/main",
+            files=[FileReview(file_path="src/f.py", **file_kwargs)],
+        )
+
+    def test_coverage_included_in_body_when_present(self) -> None:
+        client = GitHubReviewClient()
+        report = self._make_report(coverage_pct=72.0, covered_lines=18, instrumented_changed_lines=25)
+        payload = client.build_payload(report)
+        assert "72.0%" in payload["body"]
+        assert "18/25" in payload["body"]
+        assert "Coverage on changed lines" in payload["body"]
+
+    def test_coverage_absent_from_body_when_none(self) -> None:
+        client = GitHubReviewClient()
+        report = self._make_report()  # coverage_pct defaults to None
+        payload = client.build_payload(report)
+        assert "Coverage on changed lines" not in payload["body"]
+
+    def test_coverage_included_in_fallback_body(self) -> None:
+        client = GitHubReviewClient()
+        report = self._make_report(coverage_pct=50.0, covered_lines=5, instrumented_changed_lines=10)
+        payload = client._build_fallback_payload(report)
+        assert "50.0%" in payload["body"]
+        assert "Coverage on changed lines" in payload["body"]

--- a/tests/review/test_models.py
+++ b/tests/review/test_models.py
@@ -411,3 +411,31 @@ class TestDuplicationModels:
         )
 
         assert result.total_duplications == 4  # 1+1 + 2+0
+
+
+class TestFileReviewCoverageFields:
+    def test_coverage_fields_default_to_none_and_zero(self) -> None:
+        fr = FileReview(file_path="src/f.py")
+        assert fr.coverage_pct is None
+        assert fr.covered_lines == 0
+        assert fr.instrumented_changed_lines == 0
+
+    def test_coverage_fields_serialise_to_dict(self) -> None:
+        fr = FileReview(file_path="src/f.py", coverage_pct=72.5, covered_lines=18, instrumented_changed_lines=25)
+        data = fr.model_dump()
+        assert data["coverage_pct"] == 72.5
+        assert data["covered_lines"] == 18
+        assert data["instrumented_changed_lines"] == 25
+
+    def test_coverage_fields_round_trip(self) -> None:
+        fr = FileReview(file_path="src/f.py", coverage_pct=50.0, covered_lines=5, instrumented_changed_lines=10)
+        restored = FileReview.model_validate(fr.model_dump())
+        assert restored.coverage_pct == 50.0
+        assert restored.covered_lines == 5
+        assert restored.instrumented_changed_lines == 10
+
+    def test_old_json_without_coverage_fields_loads_safely(self) -> None:
+        old_data = {"file_path": "src/f.py", "issues": [], "duplications": [], "resolved_duplications": []}
+        fr = FileReview.model_validate(old_data)
+        assert fr.coverage_pct is None
+        assert fr.covered_lines == 0

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -1039,3 +1039,144 @@ class TestSameFileDuplication:
         assert result[0].other_locations[0].file_path == "src/file.py"
         assert result[0].other_locations[0].from_line == 249
         assert result[0].other_locations[0].to_line == 283
+
+
+class TestRunAnalysisCoverage:
+    """Tests for the --coverage flag in run_analysis."""
+
+    @pytest.fixture
+    def mock_diff_parser(self) -> MagicMock:
+        mock = MagicMock()
+        # Default: "src/file.py" has changed lines {10, 20} so changed_lines_for_file is non-empty
+        mock.get_diff_lines.return_value = DiffLines(new_lines={"src/file.py": {10, 20}}, old_lines={})
+        mock.get_raw_diff.return_value = ""
+        return mock
+
+    @pytest.fixture
+    def orchestrator(self, config: VibeHealConfig, mock_diff_parser: MagicMock) -> ReviewOrchestrator:
+        from vibe_heal.review.orchestrator import ReviewOrchestrator
+
+        mock_client = AsyncMock()
+        return ReviewOrchestrator(config, mock_client, MagicMock(), mock_diff_parser)
+
+    def _standard_patches(self, orchestrator):
+        """All patches needed to reach the per-file loop."""
+        return (
+            _basic_analysis_patches(orchestrator),
+            patch.object(
+                orchestrator.project_manager,
+                "copy_exclusion_settings",
+                return_value=([], 0),
+            ),
+            patch.object(
+                orchestrator.analysis_runner,
+                "run_analysis",
+                return_value=AnalysisResult(success=True, task_id="t1", dashboard_url="http://d"),
+            ),
+            patch.object(orchestrator.project_manager, "delete_project", new_callable=AsyncMock),
+        )
+
+    @pytest.mark.asyncio
+    async def test_coverage_false_does_not_call_get_line_coverage(self, orchestrator, tmp_path: Path) -> None:
+        mock_glc = AsyncMock(return_value=(5, 10))
+        with ExitStack() as stack:
+            for ctx in self._standard_patches(orchestrator):
+                stack.enter_context(ctx)
+            stack.enter_context(patch.object(orchestrator.client, "get_issues", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator, "_get_active_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator, "_get_resolved_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator.client, "get_line_coverage", mock_glc))
+            result = await orchestrator.run_analysis(
+                base_branch="origin/main",
+                report_file=tmp_path / "review.json",
+                coverage=False,
+            )
+        assert result.success is True
+        mock_glc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_coverage_true_populates_coverage_pct(self, orchestrator, tmp_path: Path) -> None:
+        with ExitStack() as stack:
+            for ctx in self._standard_patches(orchestrator):
+                stack.enter_context(ctx)
+            stack.enter_context(
+                patch.object(orchestrator.client, "get_issues", AsyncMock(return_value=[_make_sonar_issue(10)]))
+            )
+            stack.enter_context(patch.object(orchestrator, "_get_active_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator, "_get_resolved_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator.client, "get_line_coverage", AsyncMock(return_value=(8, 10))))
+            stack.enter_context(patch.object(orchestrator.client, "get_rule_details", AsyncMock(return_value=None)))
+            result = await orchestrator.run_analysis(
+                base_branch="origin/main",
+                report_file=tmp_path / "review.json",
+                coverage=True,
+            )
+        assert result.success is True
+        assert len(result.files) == 1
+        fr = result.files[0]
+        assert fr.coverage_pct == 80.0
+        assert fr.covered_lines == 8
+        assert fr.instrumented_changed_lines == 10
+
+    @pytest.mark.asyncio
+    async def test_coverage_true_none_result_keeps_file_when_issues_exist(self, orchestrator, tmp_path: Path) -> None:
+        with ExitStack() as stack:
+            for ctx in self._standard_patches(orchestrator):
+                stack.enter_context(ctx)
+            stack.enter_context(
+                patch.object(orchestrator.client, "get_issues", AsyncMock(return_value=[_make_sonar_issue(10)]))
+            )
+            stack.enter_context(patch.object(orchestrator, "_get_active_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator, "_get_resolved_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator.client, "get_line_coverage", AsyncMock(return_value=None)))
+            stack.enter_context(patch.object(orchestrator.client, "get_rule_details", AsyncMock(return_value=None)))
+            result = await orchestrator.run_analysis(
+                base_branch="origin/main",
+                report_file=tmp_path / "review.json",
+                coverage=True,
+            )
+        assert result.success is True
+        assert len(result.files) == 1
+        assert result.files[0].coverage_pct is None
+
+    @pytest.mark.asyncio
+    async def test_coverage_exception_is_caught_processing_continues(self, orchestrator, tmp_path: Path) -> None:
+        with ExitStack() as stack:
+            for ctx in self._standard_patches(orchestrator):
+                stack.enter_context(ctx)
+            stack.enter_context(
+                patch.object(orchestrator.client, "get_issues", AsyncMock(return_value=[_make_sonar_issue(10)]))
+            )
+            stack.enter_context(patch.object(orchestrator, "_get_active_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator, "_get_resolved_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(
+                patch.object(
+                    orchestrator.client, "get_line_coverage", AsyncMock(side_effect=RuntimeError("network error"))
+                )
+            )
+            stack.enter_context(patch.object(orchestrator.client, "get_rule_details", AsyncMock(return_value=None)))
+            result = await orchestrator.run_analysis(
+                base_branch="origin/main",
+                report_file=tmp_path / "review.json",
+                coverage=True,
+            )
+        assert result.success is True
+        assert result.files[0].coverage_pct is None
+
+    @pytest.mark.asyncio
+    async def test_coverage_only_file_included_when_coverage_pct_not_none(self, orchestrator, tmp_path: Path) -> None:
+        """A file with no issues/dups but coverage data IS included in result.files."""
+        with ExitStack() as stack:
+            for ctx in self._standard_patches(orchestrator):
+                stack.enter_context(ctx)
+            stack.enter_context(patch.object(orchestrator.client, "get_issues", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator, "_get_active_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator, "_get_resolved_duplications", AsyncMock(return_value=[])))
+            stack.enter_context(patch.object(orchestrator.client, "get_line_coverage", AsyncMock(return_value=(3, 5))))
+            result = await orchestrator.run_analysis(
+                base_branch="origin/main",
+                report_file=tmp_path / "review.json",
+                coverage=True,
+            )
+        assert len(result.files) == 1
+        assert result.files[0].coverage_pct == 60.0

--- a/tests/review/test_reporter.py
+++ b/tests/review/test_reporter.py
@@ -201,3 +201,45 @@ class TestWriteReports:
         assert "<p>Unused variables clutter code.</p>" in md
         assert "<p>Magic numbers reduce readability.</p>" in md
         assert "python:S999" not in md.split("<details>")[1] if "<details>" in md else True
+
+
+class TestCoverageInMarkdown:
+    def _result(self, **kwargs) -> ReviewResult:
+        return ReviewResult(
+            project_key="p",
+            branch="feature/x",
+            base_branch="origin/main",
+            files=[FileReview(file_path="src/f.py", **kwargs)],
+        )
+
+    def test_coverage_pct_rendered_when_present(self, tmp_path: Path) -> None:
+        write_reports(self._result(coverage_pct=72.0, covered_lines=18, instrumented_changed_lines=25), tmp_path)
+        md = (tmp_path / "review.md").read_text()
+        assert "72.0%" in md
+        assert "18/25" in md
+
+    def test_coverage_zero_percent_rendered(self, tmp_path: Path) -> None:
+        write_reports(self._result(coverage_pct=0.0, covered_lines=0, instrumented_changed_lines=5), tmp_path)
+        md = (tmp_path / "review.md").read_text()
+        assert "0.0%" in md
+        assert "0/5" in md
+
+    def test_coverage_100_percent_rendered(self, tmp_path: Path) -> None:
+        write_reports(self._result(coverage_pct=100.0, covered_lines=10, instrumented_changed_lines=10), tmp_path)
+        md = (tmp_path / "review.md").read_text()
+        assert "100.0%" in md
+
+    def test_no_coverage_line_when_coverage_pct_none(self, tmp_path: Path) -> None:
+        write_reports(self._result(), tmp_path)  # coverage_pct defaults to None
+        md = (tmp_path / "review.md").read_text()
+        assert "Coverage on changed lines" not in md
+
+    def test_no_issues_label_absent_when_only_coverage_present(self, tmp_path: Path) -> None:
+        """A file with only coverage data (no issues/dups) must not show 'No issues.'"""
+        write_reports(
+            self._result(coverage_pct=80.0, covered_lines=8, instrumented_changed_lines=10),
+            tmp_path,
+        )
+        md = (tmp_path / "review.md").read_text()
+        assert "No issues." not in md
+        assert "80.0%" in md

--- a/tests/sonarqube/test_client.py
+++ b/tests/sonarqube/test_client.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -13,6 +14,16 @@ from vibe_heal.sonarqube import (
     SonarQubeAuthError,
     SonarQubeClient,
 )
+from vibe_heal.sonarqube.exceptions import ComponentNotFoundError
+from vibe_heal.sonarqube.models import SourceLine
+
+
+def _make_line(line: int, line_hits: int | None) -> SourceLine:
+    """Build a SourceLine with a specific lineHits value."""
+    data: dict[str, object] = {"line": line, "code": "x"}
+    if line_hits is not None:
+        data["lineHits"] = line_hits
+    return SourceLine.model_validate(data)
 
 
 @pytest.fixture
@@ -543,3 +554,82 @@ class TestGetSourceLinesProjectKey:
         async with SonarQubeClient(config) as client:
             await client.get_source_lines("src/file.py", project_key="temp-abc-123")
         assert route.calls.last.request.url.params["key"] == "temp-abc-123:src/file.py"
+
+
+class TestGetLineCoverage:
+    @pytest.mark.asyncio
+    async def test_empty_changed_lines_returns_none(self, config: VibeHealConfig) -> None:
+        async with SonarQubeClient(config) as client:
+            result = await client.get_line_coverage("src/f.py", set())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_component_not_found_returns_none(self, config: VibeHealConfig) -> None:
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", AsyncMock(side_effect=ComponentNotFoundError("not found"))):
+                result = await client.get_line_coverage("src/f.py", {10, 20})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_all_changed_lines_covered(self, config: VibeHealConfig) -> None:
+        source_lines = [_make_line(10, 2), _make_line(20, 1)]
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", AsyncMock(return_value=source_lines)):
+                result = await client.get_line_coverage("src/f.py", {10, 20})
+        assert result == (2, 2)
+
+    @pytest.mark.asyncio
+    async def test_no_changed_lines_covered(self, config: VibeHealConfig) -> None:
+        source_lines = [_make_line(10, 0), _make_line(20, 0)]
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", AsyncMock(return_value=source_lines)):
+                result = await client.get_line_coverage("src/f.py", {10, 20})
+        assert result == (0, 2)
+
+    @pytest.mark.asyncio
+    async def test_mixed_covered_uncovered(self, config: VibeHealConfig) -> None:
+        source_lines = [_make_line(10, 3), _make_line(20, 0), _make_line(30, 1)]
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", AsyncMock(return_value=source_lines)):
+                result = await client.get_line_coverage("src/f.py", {10, 20, 30})
+        assert result == (2, 3)
+
+    @pytest.mark.asyncio
+    async def test_all_non_instrumented_returns_none(self, config: VibeHealConfig) -> None:
+        source_lines = [_make_line(10, None), _make_line(20, None)]
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", AsyncMock(return_value=source_lines)):
+                result = await client.get_line_coverage("src/f.py", {10, 20})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_source_lines_response_returns_none(self, config: VibeHealConfig) -> None:
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", AsyncMock(return_value=[])):
+                result = await client.get_line_coverage("src/f.py", {10, 20})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_passes_project_key_to_get_source_lines(self, config: VibeHealConfig) -> None:
+        mock_gsl = AsyncMock(return_value=[_make_line(10, 1)])
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", mock_gsl):
+                await client.get_line_coverage("src/f.py", {10}, project_key="temp-xyz")
+        mock_gsl.assert_called_once_with("src/f.py", from_line=10, to_line=10, project_key="temp-xyz")
+
+    @pytest.mark.asyncio
+    async def test_passes_min_max_bounds_to_get_source_lines(self, config: VibeHealConfig) -> None:
+        mock_gsl = AsyncMock(return_value=[_make_line(10, 1), _make_line(30, 0)])
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", mock_gsl):
+                await client.get_line_coverage("src/f.py", {10, 20, 30})
+        mock_gsl.assert_called_once_with("src/f.py", from_line=10, to_line=30, project_key=None)
+
+    @pytest.mark.asyncio
+    async def test_only_counts_lines_in_changed_set(self, config: VibeHealConfig) -> None:
+        # Source returns lines 10, 15, 20 but only 10 and 20 are in changed_lines
+        source_lines = [_make_line(10, 1), _make_line(15, 0), _make_line(20, 1)]
+        async with SonarQubeClient(config) as client:
+            with patch.object(client, "get_source_lines", AsyncMock(return_value=source_lines)):
+                result = await client.get_line_coverage("src/f.py", {10, 20})
+        assert result == (2, 2)  # line 15 excluded

--- a/tests/sonarqube/test_client.py
+++ b/tests/sonarqube/test_client.py
@@ -521,3 +521,25 @@ class TestSonarQubeClient:
         async with SonarQubeClient(config) as client:
             with pytest.raises(SonarQubeRuleNotFoundError):
                 await client.get_rule_details("external_eslint_repo:vibe-types/no-callback-pyramid")
+
+
+class TestGetSourceLinesProjectKey:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_uses_config_project_key_by_default(self, config: VibeHealConfig) -> None:
+        route = respx.get("https://sonar.test.com/api/sources/lines").mock(
+            return_value=httpx.Response(200, json={"sources": [{"line": 1, "code": "x"}]})
+        )
+        async with SonarQubeClient(config) as client:
+            await client.get_source_lines("src/file.py")
+        assert route.calls.last.request.url.params["key"] == "my-project:src/file.py"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_uses_provided_project_key(self, config: VibeHealConfig) -> None:
+        route = respx.get("https://sonar.test.com/api/sources/lines").mock(
+            return_value=httpx.Response(200, json={"sources": [{"line": 1, "code": "x"}]})
+        )
+        async with SonarQubeClient(config) as client:
+            await client.get_source_lines("src/file.py", project_key="temp-abc-123")
+        assert route.calls.last.request.url.params["key"] == "temp-abc-123:src/file.py"

--- a/tests/sonarqube/test_models.py
+++ b/tests/sonarqube/test_models.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from vibe_heal.sonarqube.models import IssuesResponse, SonarQubeIssue
+from vibe_heal.sonarqube.models import IssuesResponse, SonarQubeIssue, SourceLine
 
 
 class TestSonarQubeIssue:
@@ -174,3 +174,27 @@ class TestIssuesResponse:
 
         assert response.issues == []
         assert response.paging == {}
+
+
+class TestSourceLineLineCoverage:
+    def test_line_hits_parsed_when_present(self) -> None:
+        sl = SourceLine.model_validate({"line": 24, "code": "x", "lineHits": 3})
+        assert sl.line_hits == 3
+
+    def test_line_hits_zero_parsed(self) -> None:
+        sl = SourceLine.model_validate({"line": 24, "code": "x", "lineHits": 0})
+        assert sl.line_hits == 0
+
+    def test_line_hits_none_when_absent(self) -> None:
+        sl = SourceLine.model_validate({"line": 24, "code": "x"})
+        assert sl.line_hits is None
+
+    def test_unknown_fields_still_ignored(self) -> None:
+        sl = SourceLine.model_validate({
+            "line": 1,
+            "code": "y",
+            "lineHits": 1,
+            "utLineHits": 1,
+            "someFutureField": "ignored",
+        })
+        assert sl.line_hits == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -905,3 +905,63 @@ class TestReviewCommand:
 
         assert result.exit_code == 0
         assert "review" in result.stdout
+
+
+class TestDisplayReviewResultsCoverage:
+    def test_no_crash_with_coverage_data(self) -> None:
+        """_display_review_results runs without error when coverage data is present."""
+        from vibe_heal.cli import _display_review_results
+        from vibe_heal.review.models import FileReview
+        from vibe_heal.review.orchestrator import ReviewAnalysisResult
+
+        result = ReviewAnalysisResult(
+            success=True,
+            project_key="p",
+            branch="feature/x",
+            base_branch="main",
+            files=[
+                FileReview(
+                    file_path="src/f.py",
+                    coverage_pct=72.0,
+                    covered_lines=18,
+                    instrumented_changed_lines=25,
+                ),
+            ],
+            files_analyzed=1,
+        )
+        _display_review_results(result)  # must not raise
+
+    def test_no_crash_without_coverage_data(self) -> None:
+        """_display_review_results runs without error when no coverage data."""
+        from vibe_heal.cli import _display_review_results
+        from vibe_heal.review.models import FileReview
+        from vibe_heal.review.orchestrator import ReviewAnalysisResult
+
+        result = ReviewAnalysisResult(
+            success=True,
+            project_key="p",
+            branch="feature/x",
+            base_branch="main",
+            files=[FileReview(file_path="src/f.py")],
+            files_analyzed=1,
+        )
+        _display_review_results(result)  # must not raise; no Coverage column
+
+    def test_mixed_coverage_and_no_coverage_files(self) -> None:
+        """Multiple files where only some have coverage_pct."""
+        from vibe_heal.cli import _display_review_results
+        from vibe_heal.review.models import FileReview
+        from vibe_heal.review.orchestrator import ReviewAnalysisResult
+
+        result = ReviewAnalysisResult(
+            success=True,
+            project_key="p",
+            branch="feature/x",
+            base_branch="main",
+            files=[
+                FileReview(file_path="src/a.py", coverage_pct=50.0, covered_lines=5, instrumented_changed_lines=10),
+                FileReview(file_path="src/b.py"),  # no coverage data → shown as "—"
+            ],
+            files_analyzed=2,
+        )
+        _display_review_results(result)  # must not raise


### PR DESCRIPTION
  - Adds an opt-in --coverage flag to vibe-heal review that fetches per-line test coverage data from SonarQube for changed lines and reports the percentage
  covered per file
  - Coverage is surfaced in both the terminal table (a conditional "Coverage" column) and the per-file markdown report section
  - Coverage fetch failures are non-fatal: a warning is printed and the review continues normally

  How it works

  When --coverage is passed, the orchestrator calls the new SonarQubeClient.get_line_coverage() method for each modified file. That method fetches source lines
  from /api/sources/lines, filters to the changed lines that have coverage data (lineHits not null), and returns (covered_lines, instrumented_changed_lines).
  The result is stored on FileReview as coverage_pct, covered_lines, and instrumented_changed_lines.

  A file with only coverage data (no issues or duplications) is included in the report when --coverage is on.

  Changes

│                 File                 │                                               Change                                               │
│ src/vibe_heal/sonarqube/models.py    │ Add line_hits: int | None field to SourceLine (maps lineHits from API) │
│ src/vibe_heal/sonarqube/client.py    │ Add optional project_key param to get_source_lines; add get_line_coverage() method                 │
  │ src/vibe_heal/review/models.py       │ Add coverage_pct, covered_lines, instrumented_changed_lines to FileReview│
  │ src/vibe_heal/review/orchestrator.py │ Add coverage: bool = False to run_analysis; add _fetch_coverage() helper│
  │ src/vibe_heal/review/reporter.py     │ Render coverage line in markdown; fix "No issues." guard for coverage-only files│
  │ src/vibe_heal/cli.py                 │ Add --coverage flag; thread through _run_review; add conditional column in _display_review_results │
 
  Test plan

  - [ ] make check passes (ruff, mypy, deptry)
  - [ ] make test passes (581 tests)
  - [ ] vibe-heal review --help shows --coverage flag with correct help text
  - [ ] Run vibe-heal review --coverage against a real branch with SonarQube coverage data and verify the coverage column appears in the terminal and the
  markdown report

  Notes

  - Coverage fetch is skipped silently when sonar-scanner was run without test execution (no lineHits data) — a dim message is shown in --verbose mode
  - _fetch_coverage() was extracted from run_analysis to keep the method within the ruff C901 complexity limit (10)
  - Old review.json files without coverage fields deserialize safely to defaults (coverage_pct=None, counts=0)

