### PR TITLE
fix: cap inline PR review comments to avoid GitHub secondary rate limit

### DIFF
--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from urllib.parse import urlparse
 
 from vibe_heal.ai_tools.utils import run_command
+from vibe_heal.output import warn
 from vibe_heal.review.models import FileReview, ReviewIssue, ReviewResult
 from vibe_heal.review.reporter import format_coverage_table
 
@@ -20,6 +21,9 @@ class GitHubReviewError(Exception):
 
 class NoOpenPrError(GitHubReviewError):
     """Raised when there is no open PR for the current branch."""
+
+
+_MAX_INLINE_COMMENTS = 50
 
 
 class GitHubReviewClient:
@@ -113,12 +117,7 @@ class GitHubReviewClient:
                 "Inline review failed (%s) — falling back to top-level comment",
                 inline_err,
             )
-            from rich.console import Console as _Console
-
-            _Console(stderr=True).print(
-                f"[yellow]Warning: inline review rejected by GitHub ({inline_err}) — "
-                "posting as a top-level comment instead.[/yellow]"
-            )
+            warn(f"Warning: inline review rejected by GitHub ({inline_err}) — posting as a top-level comment instead.")
             fallback = self._build_fallback_payload(report)
             try:
                 await self._post_json(
@@ -142,11 +141,21 @@ class GitHubReviewClient:
         nearby_lines: list[str] = []
         for file_review in report.files:
             self._collect_file_comments(file_review, report.base_branch, comments, nearby_lines)
-        total_findings = len(comments) + len(nearby_lines)
+
+        total_before_cap = len(comments)
+        if total_before_cap > _MAX_INLINE_COMMENTS:
+            overflow: list[dict[str, Any]] = comments[_MAX_INLINE_COMMENTS:]
+            comments = comments[:_MAX_INLINE_COMMENTS]
+        else:
+            overflow = []
+
+        total_findings = total_before_cap + len(nearby_lines)
         if total_findings:
             breakdown = []
             if comments:
                 breakdown.append(f"{len(comments)} inline")
+            if overflow:
+                breakdown.append(f"{len(overflow)} capped")
             if nearby_lines:
                 breakdown.append(f"{len(nearby_lines)} near changed lines")
             summary = f"SonarQube: {total_findings} finding(s) ({', '.join(breakdown)})."
@@ -157,6 +166,12 @@ class GitHubReviewClient:
             body_parts.append(
                 "**Issues near changed lines** (outside diff — shown here instead of inline):\n"
                 + "\n".join(nearby_lines)
+            )
+        if overflow:
+            overflow_lines = [f"- **{c['path']}:{c['line']}** {c['body'].splitlines()[0]}" for c in overflow]
+            body_parts.append(
+                f"**{len(overflow)} finding(s) over the {_MAX_INLINE_COMMENTS}-comment inline limit**"
+                " (capped to avoid GitHub rate limits):\n" + "\n".join(overflow_lines)
             )
         files_with_coverage = [fr for fr in report.files if fr.coverage_pct is not None]
         if files_with_coverage:

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -24,6 +24,7 @@ class NoOpenPrError(GitHubReviewError):
 
 
 _MAX_INLINE_COMMENTS = 50
+_MAX_OVERFLOW_BODY_LINES = 100
 
 
 class GitHubReviewClient:
@@ -168,10 +169,13 @@ class GitHubReviewClient:
                 + "\n".join(nearby_lines)
             )
         if overflow:
-            overflow_lines = [f"- **{c['path']}:{c['line']}** {c['body'].splitlines()[0]}" for c in overflow]
+            visible = overflow[:_MAX_OVERFLOW_BODY_LINES]
+            overflow_lines = [f"- **{c['path']}:{c['line']}** {c['body'].splitlines()[0]}" for c in visible]
+            extra = len(overflow) - len(visible)
+            suffix = f"\n_...and {extra} more not shown._" if extra else ""
             body_parts.append(
                 f"**{len(overflow)} finding(s) over the {_MAX_INLINE_COMMENTS}-comment inline limit**"
-                " (capped to avoid GitHub rate limits):\n" + "\n".join(overflow_lines)
+                f" (capped to avoid GitHub rate limits):\n" + "\n".join(overflow_lines) + suffix
             )
         files_with_coverage = [fr for fr in report.files if fr.coverage_pct is not None]
         if files_with_coverage:

--- a/src/vibe_heal/utils/__init__.py
+++ b/src/vibe_heal/utils/__init__.py
@@ -1,7 +1,7 @@
 """Shared utilities for vibe-heal."""
 
 from vibe_heal.models import FixSummary
-from vibe_heal.output import bold, console, error, success, warn
+from vibe_heal.output import bold, console, dim, error, success, warn
 
 
 def display_fix_summary(
@@ -16,16 +16,13 @@ def display_fix_summary(
         dry_run: Whether in dry-run mode
         total_label: Label for the total count line
     """
-    console.print("\n[bold]Summary:[/bold]")
+    bold("\nSummary:")
     console.print(f"  {total_label}: {summary.total_issues}")
     if summary.fixed:
         success(f"  Fixed: {summary.fixed}")
     else:
         console.print(f"  Fixed: {summary.fixed}")
-    if summary.failed:
-        error(f"  Failed: {summary.failed}")
-    else:
-        console.print(f"  Failed: {summary.failed}")
+    error(f"  Failed: {summary.failed}")
     if summary.skipped:
         warn(f"  Skipped: {summary.skipped}")
     else:
@@ -40,4 +37,4 @@ def display_fix_summary(
     if dry_run:
         warn("\nDry-run mode: no changes committed")
 
-    console.print("\n[dim]GitHub: https://github.com/alexeieleusis/vibe-heal[/dim]")
+    dim("\nGitHub: https://github.com/alexeieleusis/vibe-heal")

--- a/src/vibe_heal/utils/__init__.py
+++ b/src/vibe_heal/utils/__init__.py
@@ -22,7 +22,10 @@ def display_fix_summary(
         success(f"  Fixed: {summary.fixed}")
     else:
         console.print(f"  Fixed: {summary.fixed}")
-    error(f"  Failed: {summary.failed}")
+    if summary.failed:
+        error(f"  Failed: {summary.failed}")
+    else:
+        console.print(f"  Failed: {summary.failed}")
     if summary.skipped:
         warn(f"  Skipped: {summary.skipped}")
     else:

--- a/tests/review/test_github.py
+++ b/tests/review/test_github.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from vibe_heal.review.github import GitHubReviewClient, GitHubReviewError
+from vibe_heal.review.github import _MAX_INLINE_COMMENTS, GitHubReviewClient, GitHubReviewError
 from vibe_heal.review.models import FileReview, ReviewIssue, ReviewResult
 
 
@@ -569,3 +569,46 @@ class TestBuildPayloadCoverage:
         assert "| 5 |" in payload["body"]
         assert "| 10 |" in payload["body"]
         assert "Coverage on changed lines" in payload["body"]
+
+
+class TestBuildPayloadCap:
+    def _make_report_with_n_issues(self, n: int) -> ReviewResult:
+        return ReviewResult(
+            project_key="p",
+            branch="feat",
+            base_branch="origin/main",
+            files=[
+                FileReview(
+                    file_path=f"src/file_{i}.py",
+                    issues=[ReviewIssue(rule="python:S1", message=f"Issue {i}", line=i + 1, on_changed_line=True)],
+                )
+                for i in range(n)
+            ],
+        )
+
+    def test_comments_capped_at_max(self) -> None:
+        client = GitHubReviewClient()
+        report = self._make_report_with_n_issues(_MAX_INLINE_COMMENTS + 10)
+        payload = client.build_payload(report)
+        assert len(payload["comments"]) == _MAX_INLINE_COMMENTS
+
+    def test_overflow_appears_in_body(self) -> None:
+        client = GitHubReviewClient()
+        report = self._make_report_with_n_issues(_MAX_INLINE_COMMENTS + 5)
+        payload = client.build_payload(report)
+        assert "5 finding(s) over the" in payload["body"]
+        assert "capped" in payload["body"]
+
+    def test_summary_counts_overflow(self) -> None:
+        total = _MAX_INLINE_COMMENTS + 3
+        client = GitHubReviewClient()
+        report = self._make_report_with_n_issues(total)
+        payload = client.build_payload(report)
+        assert f"{total} finding(s)" in payload["body"]
+
+    def test_under_cap_posts_all_inline(self) -> None:
+        client = GitHubReviewClient()
+        report = self._make_report_with_n_issues(5)
+        payload = client.build_payload(report)
+        assert len(payload["comments"]) == 5
+        assert "capped" not in payload["body"]

--- a/tests/review/test_github.py
+++ b/tests/review/test_github.py
@@ -598,6 +598,7 @@ class TestBuildPayloadCap:
         payload = client.build_payload(report)
         assert "5 finding(s) over the" in payload["body"]
         assert "capped" in payload["body"]
+        assert "src/file_50.py" in payload["body"]  # overflow entries are actually rendered, not just the header
 
     def test_summary_counts_overflow(self) -> None:
         total = _MAX_INLINE_COMMENTS + 3

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -23,6 +23,8 @@ def _mock_console():
         (error, "Failed: [/path/to/file]", "[red]Failed: \\[/path/to/file][/red]"),
         (info, "AI tool: [claude-code]", "[blue]AI tool: \\[claude-code][/blue]"),
         (bold_cyan, "Processing [file]", "[bold cyan]Processing \\[file][/bold cyan]"),
+        (cyan, "Status [red] alert", "[cyan]Status \\[red] alert[/cyan]"),
+        (bold, "Header [red] text", "[bold]Header \\[red] text[/bold]"),
     ],
 )
 def test_helper_escapes_markup_tags(_mock_console, fn, msg, expected):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -14,56 +14,33 @@ def _mock_console():
         yield mock
 
 
-def test_dim_escapes_brackets(_mock_console):
-    dim("File [bad]")
-    _mock_console.print.assert_called_once_with("[dim]File \\[bad][/dim]")
+@pytest.mark.parametrize(
+    "fn,msg,expected",
+    [
+        (dim, "File [bad]", "[dim]File \\[bad][/dim]"),
+        (success, "[green]spoofed[/green]", "[green]\\[green]spoofed\\[/green][/green]"),
+        (warn, "Could not delete [project-key]", "[yellow]Could not delete \\[project-key][/yellow]"),
+        (error, "Failed: [/path/to/file]", "[red]Failed: \\[/path/to/file][/red]"),
+        (info, "AI tool: [claude-code]", "[blue]AI tool: \\[claude-code][/blue]"),
+        (bold_cyan, "Processing [file]", "[bold cyan]Processing \\[file][/bold cyan]"),
+    ],
+)
+def test_helper_escapes_markup_tags(_mock_console, fn, msg, expected):
+    fn(msg)
+    _mock_console.print.assert_called_once_with(expected)
 
 
-def test_success_escapes_brackets(_mock_console):
-    success("[green]spoofed[/green]")
-    _mock_console.print.assert_called_once_with("[green]\\[green]spoofed\\[/green][/green]")
-
-
-def test_warn_escapes_brackets(_mock_console):
-    warn("Could not delete [project-key]")
-    _mock_console.print.assert_called_once_with("[yellow]Could not delete \\[project-key][/yellow]")
-
-
-def test_error_escapes_brackets(_mock_console):
-    error("Failed: [/path/to/file]")
-    _mock_console.print.assert_called_once_with("[red]Failed: \\[/path/to/file][/red]")
-
-
-def test_info_escapes_brackets(_mock_console):
-    info("AI tool: [claude-code]")
-    _mock_console.print.assert_called_once_with("[blue]AI tool: \\[claude-code][/blue]")
-
-
-def test_cyan_passes_through_non_markup_brackets(_mock_console):
-    cyan("Found [3] items")
-    # [3] is not a markup tag so rich.markup.escape leaves it alone
-    _mock_console.print.assert_called_once_with("[cyan]Found [3] items[/cyan]")
-
-
-def test_cyan_escapes_markup_tag_tokens(_mock_console):
-    cyan("Status [red] alert")
-    _mock_console.print.assert_called_once_with("[cyan]Status \\[red] alert[/cyan]")
-
-
-def test_bold_cyan_escapes_brackets(_mock_console):
-    bold_cyan("Processing [file]")
-    _mock_console.print.assert_called_once_with("[bold cyan]Processing \\[file][/bold cyan]")
-
-
-def test_bold_passes_through_non_markup_brackets(_mock_console):
-    bold("Header [1]")
-    # [1] is not a markup tag so rich.markup.escape leaves it alone
-    _mock_console.print.assert_called_once_with("[bold]Header [1][/bold]")
-
-
-def test_bold_escapes_markup_tag_tokens(_mock_console):
-    bold("Header [red] text")
-    _mock_console.print.assert_called_once_with("[bold]Header \\[red] text[/bold]")
+@pytest.mark.parametrize(
+    "fn,msg,expected",
+    [
+        # [3] and [1] are not valid Rich markup tags — escape leaves them as-is
+        (cyan, "Found [3] items", "[cyan]Found [3] items[/cyan]"),
+        (bold, "Header [1]", "[bold]Header [1][/bold]"),
+    ],
+)
+def test_helper_passes_through_non_tag_brackets(_mock_console, fn, msg, expected):
+    fn(msg)
+    _mock_console.print.assert_called_once_with(expected)
 
 
 def test_plain_strings_pass_through(_mock_console):


### PR DESCRIPTION
## Summary

- Caps inline comments in GitHub PR reviews to 50 to avoid hitting GitHub's secondary rate limit (80/min, 500/hr)
- Overflow findings are rendered as plain text in the review body so no findings are silently dropped
- Adds tests covering the overflow behavior

## Test plan

- [ ] Run `uv run pytest tests/review/test_github.py -v` to verify the new tests pass
- [ ] Run `make check` to confirm no linting/type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)