### PR TITLE
fix: surface SonarQube error reason on server-side analysis failure

### DIFF
--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -627,7 +627,7 @@ def _display_review_results(result: ReviewAnalysisResult) -> None:
 
     if result.files:
         _build_review_table(result)
-    elif total_issues == 0 and total_duplications == 0:
+    elif result.success and total_issues == 0 and total_duplications == 0:
         console.print("\n[green]No issues found on changed lines.[/green]")
 
     if result.report_file:

--- a/src/vibe_heal/sonarqube/analysis_runner.py
+++ b/src/vibe_heal/sonarqube/analysis_runner.py
@@ -57,6 +57,7 @@ class AnalysisRunner:
         project_name: str,
         project_dir: Path,
         sources: list[Path] | None = None,
+        max_retries: int = 2,
     ) -> AnalysisResult:
         """Run SonarQube analysis on project.
 
@@ -65,6 +66,7 @@ class AnalysisRunner:
             project_name: SonarQube project name
             project_dir: Root directory to analyze
             sources: Optional list of specific files/dirs to analyze (relative to project_dir)
+            max_retries: How many times to retry if server-side analysis fails (not for scanner errors)
 
         Returns:
             AnalysisResult with success status and details
@@ -72,7 +74,6 @@ class AnalysisRunner:
         Raises:
             SonarQubeAPIError: If scanner execution fails or analysis times out
         """
-        # Check scanner is available
         if not self.validate_scanner_available():
             return AnalysisResult(
                 success=False,
@@ -83,97 +84,95 @@ class AnalysisRunner:
         handler = SonarPropertiesHandler(project_dir, self.config)
         command = handler.build_command(project_key, project_name, sources)
 
-        # Execute scanner
+        result = AnalysisResult(success=False, error_message="No analysis attempt made")
         with handler.patched(project_key, project_name):
-            try:
-                dim(f"    Executing: sonar-scanner (project: {project_key})")
-                result = await asyncio.create_subprocess_exec(
-                    *command,
-                    cwd=str(project_dir),
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-
-                dim("    Waiting for scanner to complete...")
-                stdout, stderr = await result.communicate()
-                dim(f"    Scanner finished with exit code: {result.returncode}")
-
-                if result.returncode != 0:
-                    stdout_text = stdout.decode() if stdout else ""
-                    stderr_text = stderr.decode() if stderr else ""
-                    combined_error_output = "\n".join(output for output in (stderr_text, stdout_text) if output)
-                    error(f"    Scanner error: {combined_error_output[:500]}")
-                    error_msg = f"sonar-scanner failed with exit code {result.returncode}: {combined_error_output}"
-                    if handler.exists and _AUTH_ERROR_RE.search(combined_error_output):
-                        error_msg += _AUTH_HINT
-                    return AnalysisResult(
-                        success=False,
-                        error_message=error_msg,
+            for attempt in range(max_retries + 1):
+                if attempt > 0:
+                    retry_delay = 10 * 2 ** (attempt - 1)
+                    warn(
+                        f"    Server-side analysis failed, retrying in {retry_delay}s"
+                        f" (attempt {attempt + 1} of {max_retries + 1})..."
                     )
-
-                # Extract task ID from scanner output
-                scanner_output = stdout.decode()
-                dim("    Extracting task ID from scanner output...")
-                task_id = self._extract_task_id(scanner_output)
-
-                if not task_id:
-                    error("    Could not find task ID in scanner output")
-                    dim("    See debug log for full scanner output")
-                    # Log full scanner output to debug log for troubleshooting
-                    logger.debug("Full scanner output when task ID extraction failed:\n%s", scanner_output)
-                    return AnalysisResult(
-                        success=False,
-                        error_message="Could not extract task ID from scanner output",
-                    )
-
-                dim(f"    Task ID: {task_id}")
-
-                # Wait for analysis to complete on server
-                dim("    Waiting for server-side analysis to complete...")
+                    await asyncio.sleep(retry_delay)
                 try:
-                    async with asyncio.timeout(300):
-                        analysis_success = await self._wait_for_analysis(task_id)
-                except TimeoutError:
-                    error("    Analysis timed out after 300 seconds")
-                    return AnalysisResult(
-                        success=False,
-                        task_id=task_id,
-                        error_message="Analysis timed out after 300 seconds",
-                    )
+                    result = await self._run_scanner_attempt(command, project_key, project_dir, handler)
+                except Exception as e:
+                    return AnalysisResult(success=False, error_message=f"Failed to run analysis: {e}")
+                if result.success or not (result.error_message or "").startswith("Analysis failed on server"):
+                    return result
+        return result
 
-                if not analysis_success:
-                    error("    Analysis failed on server")
-                    return AnalysisResult(
-                        success=False,
-                        task_id=task_id,
-                        error_message="Analysis failed on server",
-                    )
+    async def _run_scanner_attempt(
+        self,
+        command: list[str],
+        project_key: str,
+        project_dir: Path,
+        handler: SonarPropertiesHandler,
+    ) -> AnalysisResult:
+        """Execute sonar-scanner once and wait for server-side completion."""
+        dim(f"    Executing: sonar-scanner (project: {project_key})")
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(project_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
 
-                success("    ✓ Server-side analysis completed successfully")
+        dim("    Waiting for scanner to complete...")
+        stdout, stderr = await proc.communicate()
+        dim(f"    Scanner finished with exit code: {proc.returncode}")
 
-                # Build dashboard URL
-                dashboard_url = f"{self.config.sonarqube_url}/dashboard?id={project_key}"
+        if proc.returncode != 0:
+            stdout_text = stdout.decode() if stdout else ""
+            stderr_text = stderr.decode() if stderr else ""
+            combined = "\n".join(o for o in (stderr_text, stdout_text) if o)
+            error(f"    Scanner error: {combined[:500]}")
+            error_msg = f"sonar-scanner failed with exit code {proc.returncode}: {combined}"
+            if handler.exists and _AUTH_ERROR_RE.search(combined):
+                error_msg += _AUTH_HINT
+            return AnalysisResult(success=False, error_message=error_msg)
 
-                return AnalysisResult(
-                    success=True,
-                    task_id=task_id,
-                    dashboard_url=dashboard_url,
-                )
+        scanner_output = stdout.decode()
+        dim("    Extracting task ID from scanner output...")
+        task_id = self._extract_task_id(scanner_output)
 
-            except Exception as e:
-                return AnalysisResult(
-                    success=False,
-                    error_message=f"Failed to run analysis: {e}",
-                )
+        if not task_id:
+            error("    Could not find task ID in scanner output")
+            dim("    See debug log for full scanner output")
+            logger.debug("Full scanner output when task ID extraction failed:\n%s", scanner_output)
+            return AnalysisResult(success=False, error_message="Could not extract task ID from scanner output")
 
-    async def _wait_for_analysis(self, task_id: str) -> bool:
+        dim(f"    Task ID: {task_id}")
+        dim("    Waiting for server-side analysis to complete...")
+        try:
+            async with asyncio.timeout(300):
+                analysis_success, server_error = await self._wait_for_analysis(task_id)
+        except TimeoutError:
+            error("    Analysis timed out after 300 seconds")
+            return AnalysisResult(success=False, task_id=task_id, error_message="Analysis timed out after 300 seconds")
+
+        if analysis_success:
+            success("    ✓ Server-side analysis completed successfully")
+            return AnalysisResult(
+                success=True,
+                task_id=task_id,
+                dashboard_url=f"{self.config.sonarqube_url}/dashboard?id={project_key}",
+            )
+
+        error_message = "Analysis failed on server"
+        if server_error:
+            error_message += f": {server_error}"
+        error(f"    {error_message}")
+        return AnalysisResult(success=False, task_id=task_id, error_message=error_message)
+
+    async def _wait_for_analysis(self, task_id: str) -> tuple[bool, str | None]:
         """Poll SonarQube for analysis completion.
 
         Args:
             task_id: Analysis task ID from scanner
 
         Returns:
-            True if analysis succeeded, False if failed or timed out
+            (True, None) if analysis succeeded; (False, errorMessage | None) if failed or canceled
         """
         poll_interval = 2  # seconds between polls
         last_status = None
@@ -192,10 +191,14 @@ class AnalysisRunner:
                     last_status = status
 
                 if status == "SUCCESS":
-                    return True
+                    return True, None
                 if status in ("FAILED", "CANCELED"):
-                    error(f"    Analysis failed with status: {status}")
-                    return False
+                    server_reason = task.get("errorMessage")
+                    msg = f"    Analysis failed with status: {status}"
+                    if server_reason:
+                        msg += f" — {server_reason}"
+                    error(msg)
+                    return False, server_reason
 
                 # Status is PENDING or IN_PROGRESS, keep waiting
                 await asyncio.sleep(poll_interval)

--- a/src/vibe_heal/sonarqube/analysis_runner.py
+++ b/src/vibe_heal/sonarqube/analysis_runner.py
@@ -29,6 +29,7 @@ class AnalysisResult(BaseModel):
     """Result of a SonarQube analysis run."""
 
     success: bool
+    retryable: bool = False  # True only for transient server-side failures
     task_id: str | None = None
     dashboard_url: str | None = None
     error_message: str | None = None
@@ -98,7 +99,7 @@ class AnalysisRunner:
                     result = await self._run_scanner_attempt(command, project_key, project_dir, handler)
                 except Exception as e:
                     return AnalysisResult(success=False, error_message=f"Failed to run analysis: {e}")
-                if result.success or not (result.error_message or "").startswith("Analysis failed on server"):
+                if result.success or not result.retryable:
                     return result
         return result
 
@@ -163,7 +164,7 @@ class AnalysisRunner:
         if server_error:
             error_message += f": {server_error}"
         error(f"    {error_message}")
-        return AnalysisResult(success=False, task_id=task_id, error_message=error_message)
+        return AnalysisResult(success=False, retryable=True, task_id=task_id, error_message=error_message)
 
     async def _wait_for_analysis(self, task_id: str) -> tuple[bool, str | None]:
         """Poll SonarQube for analysis completion.

--- a/tests/sonarqube/test_analysis_runner.py
+++ b/tests/sonarqube/test_analysis_runner.py
@@ -313,7 +313,7 @@ INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=
 
         with (
             patch.object(analysis_runner, "validate_scanner_available", return_value=True),
-            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_create,
             patch.object(
                 analysis_runner,
                 "_wait_for_analysis",
@@ -330,6 +330,7 @@ INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=
 
         assert result.success is True
         assert result.task_id == "AY123"
+        assert mock_create.call_count == 2
 
     @pytest.mark.asyncio
     async def test_analysis_exhausts_retries(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
@@ -343,7 +344,7 @@ INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=
 
         with (
             patch.object(analysis_runner, "validate_scanner_available", return_value=True),
-            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_create,
             patch.object(
                 analysis_runner,
                 "_wait_for_analysis",
@@ -361,6 +362,7 @@ INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=
         assert result.success is False
         assert "failed on server" in result.error_message
         assert "Fail to extract report from database" in result.error_message
+        assert mock_create.call_count == 3
 
     @pytest.mark.asyncio
     async def test_analysis_timeout_on_server(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:

--- a/tests/sonarqube/test_analysis_runner.py
+++ b/tests/sonarqube/test_analysis_runner.py
@@ -445,6 +445,16 @@ class TestAnalysisResult:
         assert result.task_id is None
         assert result.dashboard_url is None
 
+    def test_retryable_defaults_to_false(self) -> None:
+        """Test that retryable is False by default so non-server failures are not retried."""
+        result = AnalysisResult(success=False, error_message="Some error")
+        assert result.retryable is False
+
+    def test_retryable_true_for_server_failure(self) -> None:
+        """Test that retryable can be set explicitly for server-side failures."""
+        result = AnalysisResult(success=False, retryable=True, error_message="Analysis failed on server")
+        assert result.retryable is True
+
 
 class TestAuthHint:
     @pytest.mark.asyncio

--- a/tests/sonarqube/test_analysis_runner.py
+++ b/tests/sonarqube/test_analysis_runner.py
@@ -99,9 +99,10 @@ class TestWaitForAnalysis:
         """Test when analysis succeeds on first poll."""
         mock_client._request.return_value = {"task": {"status": "SUCCESS"}}
 
-        result = await analysis_runner._wait_for_analysis("test-task-id")
+        ok, reason = await analysis_runner._wait_for_analysis("test-task-id")
 
-        assert result is True
+        assert ok is True
+        assert reason is None
         mock_client._request.assert_called_once()
 
     @pytest.mark.asyncio
@@ -116,28 +117,43 @@ class TestWaitForAnalysis:
             {"task": {"status": "SUCCESS"}},
         ]
 
-        result = await analysis_runner._wait_for_analysis("test-task-id")
+        ok, reason = await analysis_runner._wait_for_analysis("test-task-id")
 
-        assert result is True
+        assert ok is True
+        assert reason is None
         assert mock_client._request.call_count == 3
 
     @pytest.mark.asyncio
     async def test_analysis_fails(self, analysis_runner: AnalysisRunner, mock_client: AsyncMock) -> None:
         """Test when analysis fails."""
+        mock_client._request.return_value = {"task": {"status": "FAILED", "errorMessage": "Out of memory"}}
+
+        ok, reason = await analysis_runner._wait_for_analysis("test-task-id")
+
+        assert ok is False
+        assert reason == "Out of memory"
+
+    @pytest.mark.asyncio
+    async def test_analysis_fails_no_error_message(
+        self, analysis_runner: AnalysisRunner, mock_client: AsyncMock
+    ) -> None:
+        """Test when analysis fails without an errorMessage from SonarQube."""
         mock_client._request.return_value = {"task": {"status": "FAILED"}}
 
-        result = await analysis_runner._wait_for_analysis("test-task-id")
+        ok, reason = await analysis_runner._wait_for_analysis("test-task-id")
 
-        assert result is False
+        assert ok is False
+        assert reason is None
 
     @pytest.mark.asyncio
     async def test_analysis_canceled(self, analysis_runner: AnalysisRunner, mock_client: AsyncMock) -> None:
         """Test when analysis is canceled."""
         mock_client._request.return_value = {"task": {"status": "CANCELED"}}
 
-        result = await analysis_runner._wait_for_analysis("test-task-id")
+        ok, reason = await analysis_runner._wait_for_analysis("test-task-id")
 
-        assert result is False
+        assert ok is False
+        assert reason is None
 
     @pytest.mark.asyncio
     async def test_analysis_timeout(self, analysis_runner: AnalysisRunner, mock_client: AsyncMock) -> None:
@@ -161,9 +177,10 @@ class TestWaitForAnalysis:
             {"task": {"status": "SUCCESS"}},
         ]
 
-        result = await analysis_runner._wait_for_analysis("test-task-id")
+        ok, reason = await analysis_runner._wait_for_analysis("test-task-id")
 
-        assert result is True
+        assert ok is True
+        assert reason is None
         assert mock_client._request.call_count == 2
 
 
@@ -202,7 +219,7 @@ INFO: Analysis total time: 10.234 s
         with (
             patch.object(analysis_runner, "validate_scanner_available", return_value=True),
             patch("asyncio.create_subprocess_exec", return_value=mock_process),
-            patch.object(analysis_runner, "_wait_for_analysis", return_value=True),
+            patch.object(analysis_runner, "_wait_for_analysis", return_value=(True, None)),
         ):
             result = await analysis_runner.run_analysis(
                 project_key="test-key",
@@ -270,17 +287,80 @@ INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=
         with (
             patch.object(analysis_runner, "validate_scanner_available", return_value=True),
             patch("asyncio.create_subprocess_exec", return_value=mock_process),
-            patch.object(analysis_runner, "_wait_for_analysis", return_value=False),
+            patch.object(analysis_runner, "_wait_for_analysis", return_value=(False, "Out of memory")),
         ):
             result = await analysis_runner.run_analysis(
                 project_key="test-key",
                 project_name="Test Project",
                 project_dir=tmp_path,
+                max_retries=0,
             )
 
         assert result.success is False
         assert result.task_id == "AY123"
         assert "failed on server" in result.error_message
+        assert "Out of memory" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_analysis_succeeds_after_retry(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
+        """Test that a transient server failure is retried and eventually succeeds."""
+        scanner_output = b"""
+INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=AY123
+"""
+        mock_process = AsyncMock()
+        mock_process.returncode = 0
+        mock_process.communicate = AsyncMock(return_value=(scanner_output, b""))
+
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+            patch.object(
+                analysis_runner,
+                "_wait_for_analysis",
+                side_effect=[(False, "Fail to extract report from database"), (True, None)],
+            ),
+            patch("asyncio.sleep"),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="test-key",
+                project_name="Test Project",
+                project_dir=tmp_path,
+                max_retries=1,
+            )
+
+        assert result.success is True
+        assert result.task_id == "AY123"
+
+    @pytest.mark.asyncio
+    async def test_analysis_exhausts_retries(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
+        """Test that persistent server failures return the last failure after all retries."""
+        scanner_output = b"""
+INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=AY123
+"""
+        mock_process = AsyncMock()
+        mock_process.returncode = 0
+        mock_process.communicate = AsyncMock(return_value=(scanner_output, b""))
+
+        with (
+            patch.object(analysis_runner, "validate_scanner_available", return_value=True),
+            patch("asyncio.create_subprocess_exec", return_value=mock_process),
+            patch.object(
+                analysis_runner,
+                "_wait_for_analysis",
+                side_effect=[(False, "Fail to extract report from database")] * 3,
+            ),
+            patch("asyncio.sleep"),
+        ):
+            result = await analysis_runner.run_analysis(
+                project_key="test-key",
+                project_name="Test Project",
+                project_dir=tmp_path,
+                max_retries=2,
+            )
+
+        assert result.success is False
+        assert "failed on server" in result.error_message
+        assert "Fail to extract report from database" in result.error_message
 
     @pytest.mark.asyncio
     async def test_analysis_timeout_on_server(self, analysis_runner: AnalysisRunner, tmp_path: Path) -> None:
@@ -296,9 +376,9 @@ INFO: More about the report processing at https://sonar.test.com/api/ce/task?id=
         mock_process.communicate = AsyncMock(return_value=(scanner_output, b""))
 
         # Mock _wait_for_analysis to sleep forever (simulating timeout)
-        async def wait_forever(task_id: str) -> bool:
+        async def wait_forever(task_id: str) -> tuple[bool, str | None]:
             await asyncio.sleep(1000)
-            return True
+            return True, None
 
         with (
             patch.object(analysis_runner, "validate_scanner_available", return_value=True),


### PR DESCRIPTION
## Summary

- **`_wait_for_analysis`** now returns `(bool, str | None)` — the server's `errorMessage` field from `/api/ce/task` is propagated all the way into `AnalysisResult.error_message` instead of being discarded. Previously you'd see `Analysis failed on server` with no hint why; now it becomes `Analysis failed on server: <SonarQube reason>`.
- **`run_analysis`** retries server-side FAILED/CANCELED tasks up to 2 times (configurable via `max_retries`) with exponential back-off (10s, 20s), since these failures are often transient.
- **`cli.py`** no longer prints the misleading `No issues found on changed lines.` success message when `result.success is False` — a failed analysis left `files` empty and counts at 0, tripping the success branch.
- Extracted `_run_scanner_attempt` helper to keep `run_analysis` below ruff's complexity threshold.

## Test plan

- [ ] All 27 analysis-runner tests pass (`uv run pytest tests/sonarqube/test_analysis_runner.py -v`)
- [ ] Full suite passes (`uv run pytest -q`)
- [ ] Pre-commit hooks pass (`uv run pre-commit run -a`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)