### PR TITLE
review: auto-detect PR base branch for stacked PRs

### DIFF
--- a/docs/review-guide.md
+++ b/docs/review-guide.md
@@ -70,7 +70,7 @@ For the temporary SonarQube project created during `review`, vibe-heal patches `
 ### Analyze changed lines
 
 ```bash
-# Review all modified files vs origin/main
+# Auto-detects the current PR's base branch via gh (falls back to origin/main if no open PR is found)
 vibe-heal review
 
 # Compare against a different base branch
@@ -115,7 +115,7 @@ vibe-heal review --post --report-file /tmp/my-review.json
 
 | Flag | Default | Description |
 |---|---|---|
-| `--base-branch` / `-b` | `origin/main` | Base branch to compare against |
+| `--base-branch` / `-b` | auto-detect via `gh`, else `origin/main` | Base branch to compare against. When omitted, auto-detects the current branch's open PR base via `gh pr view` and diffs against `origin/<that>`; falls back to `origin/main` if no open PR is found (or `gh` is unavailable). Passing an explicit value skips detection. |
 | `--pattern` / `-p` | (all files) | Glob pattern to filter files (repeatable) |
 | `--report-file` | auto | Override report output path |
 | `--env-file` | `.env.vibeheal` | Path to custom config file |
@@ -125,6 +125,14 @@ vibe-heal review --post --report-file /tmp/my-review.json
 | `--dry-run` | off | With `--post`: preview comments without API calls |
 | `--pr` | auto | With `--post`: explicit GitHub PR number |
 | `--baseline` | off | Scan the real SonarQube project directly to refresh its baseline (no diff, no report). Ignores `--pr`, `--pattern`, `--coverage`, and `--base-branch` if combined. |
+
+### Stacked PRs
+
+If your branch's PR targets another branch instead of `main` (a "stacked" PR), `review` diffs against that real base automatically — no flag needed. This avoids re-reporting issues that belong to the branch below yours in the stack, which would otherwise show up twice (once on each branch's review) and increase the odds of merge conflicts as both branches "fix" the same lines independently.
+
+This requires an open PR (so `gh pr view` can report its base) and a local `origin/<base>` remote-tracking ref — if the base branch hasn't been fetched locally, the diff will fail with a "branch not found" error rather than silently falling back to `origin/main`. Run `git fetch origin <base-branch>` first if you hit this.
+
+Pass `--base-branch` explicitly to skip auto-detection entirely (e.g. in CI, or before a PR exists).
 
 ## How It Works
 

--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -26,7 +26,7 @@ from vibe_heal.orchestrator import VibeHealOrchestrator
 from vibe_heal.output import bold, bold_cyan, console, cyan, dim, error, info, success, warn
 from vibe_heal.review import NoOpenPrError, ReviewOrchestrator
 from vibe_heal.review.models import ReviewIssue
-from vibe_heal.review.orchestrator import BaselineScanResult, ReviewAnalysisResult
+from vibe_heal.review.orchestrator import DEFAULT_BASE_BRANCH, BaselineScanResult, ReviewAnalysisResult
 from vibe_heal.review.reporter import default_report_dir
 from vibe_heal.sonarqube.client import SonarQubeClient
 
@@ -35,9 +35,6 @@ app = typer.Typer(
     help="AI-powered SonarQube issue remediation tool\n\nGitHub: https://github.com/alexeieleusis/vibe-heal",
     add_completion=False,
 )
-
-# Default values
-DEFAULT_BASE_BRANCH = "origin/main"
 
 # Help text constants
 VERBOSE_OUTPUT_HELP = "Verbose output"

--- a/src/vibe_heal/cli.py
+++ b/src/vibe_heal/cli.py
@@ -636,7 +636,7 @@ def _display_review_results(result: ReviewAnalysisResult) -> None:
 
 async def _run_review(
     config: VibeHealConfig,
-    base_branch: str,
+    base_branch: str | None,
     file_patterns: list[str] | None,
     report_file: Path | None,
     verbose: bool,
@@ -646,7 +646,7 @@ async def _run_review(
 
     Args:
         config: Configuration object.
-        base_branch: Base branch to compare against.
+        base_branch: Base branch to compare against. None auto-detects via the PR's actual base branch.
         file_patterns: Optional file patterns to filter.
         report_file: Optional path override for the report; None uses the default.
         verbose: Enable verbose output.
@@ -840,11 +840,15 @@ def review(
         "--pr",
         help="GitHub PR number (override auto-detection)",
     ),
-    base_branch: str = typer.Option(
-        DEFAULT_BASE_BRANCH,
+    base_branch: str | None = typer.Option(
+        None,
         "--base-branch",
         "-b",
-        help=BASE_BRANCH_HELP,
+        help=(
+            "Base branch to compare against. If omitted, auto-detects the "
+            "current PR's actual base branch via gh, falling back to "
+            "origin/main when no open PR is found."
+        ),
     ),
     file_patterns: list[str] | None = typer.Option(
         None,

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -107,8 +107,11 @@ class GitHubReviewClient:
             return None
 
         try:
-            data: dict[str, object] = json.loads(result.stdout)
+            data = json.loads(result.stdout)
         except json.JSONDecodeError:
+            return None
+
+        if not isinstance(data, dict):
             return None
 
         base_ref = data.get("baseRefName")

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, cast
 from urllib.parse import urlparse
 
-from vibe_heal.ai_tools.utils import run_command
+from vibe_heal.ai_tools.utils import CommandResult, run_command
 from vibe_heal.output import warn
 from vibe_heal.review.models import FileReview, ReviewIssue, ReviewResult
 from vibe_heal.review.reporter import format_coverage_table
@@ -49,6 +49,11 @@ class GitHubReviewClient:
             msg = "gh CLI is not installed or not in PATH. Install it from https://cli.github.com/"
             raise OSError(msg)
 
+    async def _view_pr_field(self, field: str) -> CommandResult:
+        """Run `gh pr view --json <field>` for the current branch's PR."""
+        async with asyncio.timeout(30):
+            return await run_command(["gh", "pr", "view", "--json", field])
+
     async def detect_pr(self, pr_number: int | None = None) -> int:
         """Get the PR number for review posting.
 
@@ -67,10 +72,7 @@ class GitHubReviewClient:
             return pr_number
         await self.validate_installed()
 
-        async with asyncio.timeout(30):
-            result = await run_command(
-                ["gh", "pr", "view", "--json", "number"],
-            )
+        result = await self._view_pr_field("number")
         if not result.success:
             stderr = result.stderr.strip()
             if "no pull requests found" in stderr.lower():
@@ -93,13 +95,7 @@ class GitHubReviewClient:
         best-effort enhancement that must silently degrade.
         """
         try:
-            await self.validate_installed()
-        except OSError:
-            return None
-
-        try:
-            async with asyncio.timeout(30):
-                result = await run_command(["gh", "pr", "view", "--json", "baseRefName"])
+            result = await self._view_pr_field("baseRefName")
         except Exception:
             return None
 

--- a/src/vibe_heal/review/github.py
+++ b/src/vibe_heal/review/github.py
@@ -81,6 +81,39 @@ class GitHubReviewClient:
         data: dict[str, object] = json.loads(result.stdout)
         return cast(int, data["number"])
 
+    async def detect_pr_base_branch(self) -> str | None:
+        """Detect the base branch of the open PR for the current branch.
+
+        Returns None when gh is not installed, the call fails, there is no
+        open PR for the current branch, or the response is malformed.
+        Unlike detect_pr(), this method never raises — callers should treat
+        None as "fall back to whatever default base branch they already use."
+        This asymmetry is deliberate: detect_pr() is used when posting,
+        where "no PR" is genuinely actionable; base-branch detection is a
+        best-effort enhancement that must silently degrade.
+        """
+        try:
+            await self.validate_installed()
+        except OSError:
+            return None
+
+        try:
+            async with asyncio.timeout(30):
+                result = await run_command(["gh", "pr", "view", "--json", "baseRefName"])
+        except Exception:
+            return None
+
+        if not result.success:
+            return None
+
+        try:
+            data: dict[str, object] = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return None
+
+        base_ref = data.get("baseRefName")
+        return cast(str, base_ref) if isinstance(base_ref, str) else None
+
     async def post_review(self, pr_number: int, report: ReviewResult) -> None:
         """Post a review with inline comments on a GitHub PR.
 

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -40,9 +40,6 @@ from vibe_heal.sonarqube.project_manager import ProjectManager, TempProjectMetad
 
 logger = logging.getLogger(__name__)
 
-# Intentionally separate from cli.py's DEFAULT_BASE_BRANCH: this one is the
-# review command's own fallback when PR base-branch auto-detection finds
-# nothing, and is not shared with cleanup/dedupe-branch.
 DEFAULT_BASE_BRANCH = "origin/main"
 
 
@@ -140,7 +137,8 @@ class ReviewOrchestrator:
             return DEFAULT_BASE_BRANCH
 
         resolved = f"origin/{detected}"
-        dim(f"Auto-detected PR base branch: {resolved}")
+        if verbose:
+            dim(f"Auto-detected PR base branch: {resolved}")
         return resolved
 
     async def run_analysis(

--- a/src/vibe_heal/review/orchestrator.py
+++ b/src/vibe_heal/review/orchestrator.py
@@ -40,6 +40,11 @@ from vibe_heal.sonarqube.project_manager import ProjectManager, TempProjectMetad
 
 logger = logging.getLogger(__name__)
 
+# Intentionally separate from cli.py's DEFAULT_BASE_BRANCH: this one is the
+# review command's own fallback when PR base-branch auto-detection finds
+# nothing, and is not shared with cleanup/dedupe-branch.
+DEFAULT_BASE_BRANCH = "origin/main"
+
 
 class ReviewAnalysisResult(BaseModel):
     """Result of a review analysis operation."""
@@ -114,9 +119,33 @@ class ReviewOrchestrator:
         self.github_client = GitHubReviewClient()
         self._rule_cache: dict[str, SonarQubeRule | None] = {}
 
+    async def _resolve_base_branch(self, base_branch: str | None, verbose: bool) -> str:
+        """Resolve the base branch to diff against.
+
+        Returns base_branch unchanged if the caller passed one explicitly
+        (no gh call is made in that case — explicit intent always wins).
+        Otherwise, attempts to auto-detect the real PR base via
+        GitHubReviewClient.detect_pr_base_branch(), prefixed with "origin/"
+        to match this codebase's remote-ref convention. Falls back to
+        DEFAULT_BASE_BRANCH when no open PR is found (or gh is unavailable),
+        preserving the pre-existing behavior for that case.
+        """
+        if base_branch is not None:
+            return base_branch
+
+        detected = await self.github_client.detect_pr_base_branch()
+        if detected is None:
+            if verbose:
+                dim(f"No open PR found; using default base branch: {DEFAULT_BASE_BRANCH}")
+            return DEFAULT_BASE_BRANCH
+
+        resolved = f"origin/{detected}"
+        dim(f"Auto-detected PR base branch: {resolved}")
+        return resolved
+
     async def run_analysis(
         self,
-        base_branch: str = "origin/main",
+        base_branch: str | None = None,
         file_patterns: list[str] | None = None,
         report_file: Path | None = None,
         verbose: bool = False,
@@ -135,7 +164,10 @@ class ReviewOrchestrator:
         8. Delete temp project in finally block
 
         Args:
-            base_branch: Base branch to compare against.
+            base_branch: Base branch to compare against. When None (the
+                default), auto-detects the current branch's open PR base via
+                gh and diffs against that; falls back to "origin/main" if no
+                PR is found. Passing an explicit value skips detection.
             file_patterns: Optional list of glob patterns to filter files.
             report_file: Optional path to write the report JSON to.
                 If provided, the parent directory is used for report output.
@@ -149,6 +181,7 @@ class ReviewOrchestrator:
             ReviewAnalysisResult with success status and review data.
         """
         temp_project: TempProjectMetadata | None = None
+        base_branch = await self._resolve_base_branch(base_branch, verbose)
         branch = self.branch_analyzer.get_current_branch()
         if report_file is None:
             report_file = default_report_dir(self.config.sonarqube_project_key, branch) / "review.json"

--- a/tests/review/test_github.py
+++ b/tests/review/test_github.py
@@ -134,12 +134,25 @@ class TestDetectPrBaseBranch:
         assert result == "main"
 
     @pytest.mark.asyncio
+    async def test_returns_none_when_gh_pr_view_fails(self, mocker) -> None:
+        """detect_pr_base_branch returns None when gh pr view fails."""
+        mocker.patch(
+            "vibe_heal.review.github.run_command",
+            new_callable=AsyncMock,
+            return_value=mocker.MagicMock(success=False),
+        )
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_gh_not_installed(self, mocker) -> None:
         """detect_pr_base_branch returns None (never raises) when gh is missing."""
         mocker.patch(
             "vibe_heal.review.github.run_command",
             new_callable=AsyncMock,
-            return_value=mocker.MagicMock(success=False),
+            side_effect=FileNotFoundError("gh not found"),
         )
 
         client = GitHubReviewClient()

--- a/tests/review/test_github.py
+++ b/tests/review/test_github.py
@@ -191,6 +191,21 @@ class TestDetectPrBaseBranch:
         result = await client.detect_pr_base_branch()
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_returns_none_when_json_is_not_an_object(self, mocker) -> None:
+        """detect_pr_base_branch returns None when gh returns valid but non-object JSON."""
+
+        async def _run(cmd, **kwargs):
+            if "--version" in cmd:
+                return mocker.MagicMock(success=True, stdout="gh version 2.52.0")
+            return mocker.MagicMock(success=True, stdout="null")
+
+        mocker.patch("vibe_heal.review.github.run_command", side_effect=_run)
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result is None
+
 
 class TestPostReview:
     """Tests for post_review."""

--- a/tests/review/test_github.py
+++ b/tests/review/test_github.py
@@ -98,6 +98,100 @@ class TestDetectPr:
             await client.detect_pr()
 
 
+class TestDetectPrBaseBranch:
+    """Tests for detect_pr_base_branch."""
+
+    @pytest.mark.asyncio
+    async def test_returns_base_ref_when_gh_succeeds(self, mocker) -> None:
+        """detect_pr_base_branch returns the baseRefName from gh pr view."""
+        mocker.patch(
+            "vibe_heal.review.github.run_command",
+            new_callable=AsyncMock,
+            return_value=mocker.MagicMock(
+                success=True,
+                stdout='{"baseRefName": "feature/lower-in-stack"}',
+            ),
+        )
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result == "feature/lower-in-stack"
+
+    @pytest.mark.asyncio
+    async def test_returns_main_when_pr_targets_main(self, mocker) -> None:
+        """Non-stacked PRs (base is main) resolve the same as any other base."""
+        mocker.patch(
+            "vibe_heal.review.github.run_command",
+            new_callable=AsyncMock,
+            return_value=mocker.MagicMock(
+                success=True,
+                stdout='{"baseRefName": "main"}',
+            ),
+        )
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result == "main"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_gh_not_installed(self, mocker) -> None:
+        """detect_pr_base_branch returns None (never raises) when gh is missing."""
+        mocker.patch(
+            "vibe_heal.review.github.run_command",
+            new_callable=AsyncMock,
+            return_value=mocker.MagicMock(success=False),
+        )
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_open_pr(self, mocker) -> None:
+        """detect_pr_base_branch returns None when gh pr view fails (no PR)."""
+
+        async def _run(cmd, **kwargs):
+            if "--version" in cmd:
+                return mocker.MagicMock(success=True, stdout="gh version 2.52.0")
+            return mocker.MagicMock(success=False, stderr="no pull requests found")
+
+        mocker.patch("vibe_heal.review.github.run_command", side_effect=_run)
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_malformed_json(self, mocker) -> None:
+        """detect_pr_base_branch returns None when gh returns unparseable JSON."""
+
+        async def _run(cmd, **kwargs):
+            if "--version" in cmd:
+                return mocker.MagicMock(success=True, stdout="gh version 2.52.0")
+            return mocker.MagicMock(success=True, stdout="not json")
+
+        mocker.patch("vibe_heal.review.github.run_command", side_effect=_run)
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_base_ref_name_missing(self, mocker) -> None:
+        """detect_pr_base_branch returns None when the JSON has no baseRefName key."""
+
+        async def _run(cmd, **kwargs):
+            if "--version" in cmd:
+                return mocker.MagicMock(success=True, stdout="gh version 2.52.0")
+            return mocker.MagicMock(success=True, stdout="{}")
+
+        mocker.patch("vibe_heal.review.github.run_command", side_effect=_run)
+
+        client = GitHubReviewClient()
+        result = await client.detect_pr_base_branch()
+        assert result is None
+
+
 class TestPostReview:
     """Tests for post_review."""
 

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -137,6 +137,72 @@ class TestReviewOrchestratorInit:
         assert orchestrator.github_client is not None
 
 
+class TestResolveBaseBranch:
+    """Tests for ReviewOrchestrator._resolve_base_branch()."""
+
+    @pytest.fixture
+    def orchestrator(self, config: VibeHealConfig):
+        """Create ReviewOrchestrator with mocked git dependencies."""
+        from vibe_heal.review.orchestrator import ReviewOrchestrator
+
+        mock_client = AsyncMock()
+        mock_analyzer = MagicMock()
+        mock_parser = MagicMock()
+        return ReviewOrchestrator(config, mock_client, mock_analyzer, mock_parser)
+
+    @pytest.mark.asyncio
+    async def test_explicit_base_branch_skips_detection(self, orchestrator) -> None:
+        """An explicit base_branch is returned as-is; gh is never called."""
+        with patch.object(
+            orchestrator.github_client,
+            "detect_pr_base_branch",
+            new_callable=AsyncMock,
+        ) as mock_detect:
+            result = await orchestrator._resolve_base_branch("origin/develop", verbose=False)
+
+        assert result == "origin/develop"
+        mock_detect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_detects_when_omitted(self, orchestrator) -> None:
+        """When base_branch is None, the detected PR base is used with an origin/ prefix."""
+        with patch.object(
+            orchestrator.github_client,
+            "detect_pr_base_branch",
+            new_callable=AsyncMock,
+            return_value="feature/lower-in-stack",
+        ):
+            result = await orchestrator._resolve_base_branch(None, verbose=False)
+
+        assert result == "origin/feature/lower-in-stack"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_default_when_no_pr_found(self, orchestrator) -> None:
+        """When detection returns None (no PR / gh unavailable), fall back to origin/main."""
+        with patch.object(
+            orchestrator.github_client,
+            "detect_pr_base_branch",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await orchestrator._resolve_base_branch(None, verbose=False)
+
+        assert result == "origin/main"
+
+    @pytest.mark.asyncio
+    async def test_detected_main_resolves_like_fallback(self, orchestrator) -> None:
+        """A direct (non-stacked) PR targeting main resolves to the same value as the fallback."""
+        with patch.object(
+            orchestrator.github_client,
+            "detect_pr_base_branch",
+            new_callable=AsyncMock,
+            return_value="main",
+        ):
+            result = await orchestrator._resolve_base_branch(None, verbose=False)
+
+        assert result == "origin/main"
+
+
 class TestRunAnalysis:
     """Tests for ReviewOrchestrator.run_analysis()."""
 

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -267,6 +267,36 @@ class TestRunAnalysis:
         mock_run.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_base_branch_none_resolves_via_github_client(
+        self,
+        orchestrator,
+        tmp_path: Path,
+    ) -> None:
+        """When base_branch is None, run_analysis resolves it via GitHubReviewClient
+        before doing anything else, and the resolved value ends up on the result."""
+        with (
+            patch.object(
+                orchestrator.branch_analyzer,
+                "get_modified_files",
+                return_value=[],
+            ),
+            patch.object(
+                orchestrator.github_client,
+                "detect_pr_base_branch",
+                new_callable=AsyncMock,
+                return_value="feature/lower-in-stack",
+            ) as mock_detect,
+        ):
+            result = await orchestrator.run_analysis(
+                base_branch=None,
+                report_file=tmp_path / "review.json",
+            )
+
+        mock_detect.assert_called_once()
+        assert result.base_branch == "origin/feature/lower-in-stack"
+        assert result.success is True
+
+    @pytest.mark.asyncio
     async def test_analysis_failure_returns_error(
         self,
         orchestrator,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -729,7 +729,7 @@ class TestReviewCommand:
         assert "Total issues: 3" in result.stdout
         mock_orchestrator.run_analysis.assert_called_once()
         call_kwargs = mock_orchestrator.run_analysis.call_args.kwargs
-        assert call_kwargs["base_branch"] == "origin/main"
+        assert call_kwargs["base_branch"] is None
         assert call_kwargs["file_patterns"] is None
 
     @patch("vibe_heal.cli.SonarQubeClient")


### PR DESCRIPTION
## Summary
- `vibe-heal review` now auto-detects the current branch's real GitHub PR base via `gh pr view --json baseRefName` instead of always diffing against `origin/main` — fixes duplicate issue reports on stacked PRs (branch B opened against unmerged branch A).
- New `GitHubReviewClient.detect_pr_base_branch()` (never raises — degrades to `None` on any failure) and `ReviewOrchestrator._resolve_base_branch()` (explicit `--base-branch` always wins and skips the `gh` call; omitted falls back to `origin/main` when no PR is found).
- `cleanup` and `dedupe-branch` are intentionally untouched — same `origin/main`-only default as before.
- Docs updated (`docs/review-guide.md`) with a new "Stacked PRs" section; includes a fix for an edge case (non-dict JSON from `gh`) found during a pre-merge security review.

## Test plan
- [x] `uv run pytest -q` — 684 passed
- [x] `uv run mypy` — clean (52 source files)
- [x] `uv run pre-commit run -a` — all hooks pass
- [x] Manually verified `vibe-heal review --help` shows the new auto-detect help text with no visible default, while `vibe-heal cleanup --help` / `vibe-heal dedupe-branch --help` are unchanged (`origin/main` default)

Spec and implementation plan (with full per-task review log): `~/agents/projects/review-base-branch-autodetect/`