### PR TITLE
Fetch vibe-types knowledge files referenced in SonarQube issue messages

### DIFF
--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -159,9 +159,16 @@ async def _fetch_docs_for_urls(urls: list[str]) -> list[str]:
     return docs
 
 
-async def fetch_external_rule_docs(message: str) -> list[str]:
-    """Extract URLs from an issue message and return fetched content for each."""
-    return await _fetch_docs_for_urls(extract_urls(message))
+async def fetch_external_rule_docs(message: str, *, exclude_vibe_types: bool = False) -> list[str]:
+    """Extract URLs from an issue message and return fetched content for each.
+
+    When exclude_vibe_types is True, vibe-types knowledge-file URLs are skipped, since the
+    caller already fetched them separately via fetch_vibe_types_knowledge_docs.
+    """
+    urls = extract_urls(message)
+    if exclude_vibe_types:
+        urls = [u for u in urls if not is_vibe_types_doc_url(u)]
+    return await _fetch_docs_for_urls(urls)
 
 
 def is_vibe_types_doc_url(url: str) -> bool:

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -152,3 +152,19 @@ async def fetch_external_rule_docs(message: str) -> list[str]:
         if content is not None:
             docs.append(content)
     return docs
+
+
+def is_vibe_types_doc_url(url: str) -> bool:
+    """Return True if url points at a vibe-types knowledge file (blob/main/SHA-pinned raw form)."""
+    return _extract_rel_path(url) is not None or bool(_SHA_PINNED_RAW_RE.match(url))
+
+
+async def fetch_vibe_types_knowledge_docs(message: str) -> list[str]:
+    """Extract vibe-types knowledge-file URLs from an issue message and return fetched content for each."""
+    urls = [u for u in extract_urls(message) if is_vibe_types_doc_url(u)]
+    docs = []
+    for url in urls:
+        content = await fetch_url_content(url)
+        if content is not None:
+            docs.append(content)
+    return docs

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -105,8 +105,8 @@ async def _stream_capped(url: str, client: httpx.AsyncClient) -> str | None:
     return b"".join(chunks)[:_MAX_DOC_BYTES].decode("utf-8", errors="replace")
 
 
-async def fetch_url_content(url: str) -> str | None:
-    """Fetch the text content of a URL, returning None on any error or SSRF-blocked host."""
+async def _fetch_one(url: str) -> str | None:
+    """Fetch a single URL's content via the local submodule fast path or HTTP, no fallback."""
     local = _vibe_types_local_path(url)
     if local is not None:
         if local.exists():
@@ -128,17 +128,25 @@ async def fetch_url_content(url: str) -> str | None:
         return None
 
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-        content = await _stream_capped(fetch_url, client)
+        return await _stream_capped(fetch_url, client)
 
-    # Only retry on an actual fetch failure, one level deep: "main" never matches the SHA regex.
-    if content is None:
-        sha_match = _SHA_PINNED_RAW_RE.match(url)
-        if sha_match:
-            fallback_url = _RAW_PREFIXES[1] + sha_match.group(2)
-            logger.debug("SHA-pinned fetch failed for %s; falling back to %s", url, fallback_url)
-            return await fetch_url_content(fallback_url)
 
-    return content
+async def fetch_url_content(url: str) -> str | None:
+    """Fetch the text content of a URL, returning None on any error or SSRF-blocked host.
+
+    SHA-pinned vibe-types raw URLs fall back to the "main" branch form if the pinned fetch fails.
+    """
+    candidates = [url]
+    sha_match = _SHA_PINNED_RAW_RE.match(url)
+    if sha_match:
+        candidates.append(_RAW_PREFIXES[1] + sha_match.group(2))
+
+    for candidate in candidates:
+        content = await _fetch_one(candidate)
+        if content is not None:
+            return content
+
+    return None
 
 
 async def _fetch_docs_for_urls(urls: list[str]) -> list[str]:

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -42,6 +42,7 @@ _RAW_PREFIXES = (
     "https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/",
     "https://raw.githubusercontent.com/jpablo/vibe-types/main/",
 )
+_SHA_PINNED_RAW_RE = re.compile(r"^https://raw\.githubusercontent\.com/jpablo/vibe-types/([0-9a-fA-F]{7,40})/(.+)$")
 
 
 def _extract_rel_path(url: str) -> str | None:
@@ -116,14 +117,27 @@ async def fetch_url_content(url: str) -> str | None:
                 logger.debug("Failed to read local vibe-types file %s: %s", local, e)
         else:
             logger.debug("Local vibe-types path not found: %s (submodule not initialized?)", local)
+
     # blob URLs return HTML over HTTP — always convert to raw before fetching
-    if url.startswith(_BLOB_PREFIX):
-        url = _RAW_PREFIXES[0] + url[len(_BLOB_PREFIX) :]
-    if not _is_safe_url(url):
-        logger.debug("Blocked SSRF-risk URL: %s", url)
-        return None
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-        return await _stream_capped(url, client)
+    fetch_url = url
+    if fetch_url.startswith(_BLOB_PREFIX):
+        fetch_url = _RAW_PREFIXES[0] + fetch_url[len(_BLOB_PREFIX) :]
+
+    content = None
+    if _is_safe_url(fetch_url):
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            content = await _stream_capped(fetch_url, client)
+    else:
+        logger.debug("Blocked SSRF-risk URL: %s", fetch_url)
+
+    if content is None:
+        sha_match = _SHA_PINNED_RAW_RE.match(url)
+        if sha_match:
+            fallback_url = _RAW_PREFIXES[1] + sha_match.group(2)
+            logger.debug("SHA-pinned fetch failed for %s; falling back to %s", url, fallback_url)
+            return await fetch_url_content(fallback_url)
+
+    return content
 
 
 async def fetch_external_rule_docs(message: str) -> list[str]:

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -123,13 +123,14 @@ async def fetch_url_content(url: str) -> str | None:
     if fetch_url.startswith(_BLOB_PREFIX):
         fetch_url = _RAW_PREFIXES[0] + fetch_url[len(_BLOB_PREFIX) :]
 
-    content = None
-    if _is_safe_url(fetch_url):
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-            content = await _stream_capped(fetch_url, client)
-    else:
+    if not _is_safe_url(fetch_url):
         logger.debug("Blocked SSRF-risk URL: %s", fetch_url)
+        return None
 
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        content = await _stream_capped(fetch_url, client)
+
+    # Only retry on an actual fetch failure, one level deep: "main" never matches the SHA regex.
     if content is None:
         sha_match = _SHA_PINNED_RAW_RE.match(url)
         if sha_match:

--- a/src/vibe_heal/ai_tools/external_docs.py
+++ b/src/vibe_heal/ai_tools/external_docs.py
@@ -141,17 +141,19 @@ async def fetch_url_content(url: str) -> str | None:
     return content
 
 
-async def fetch_external_rule_docs(message: str) -> list[str]:
-    """Extract URLs from an issue message and return fetched content for each."""
-    urls = extract_urls(message)
-    if not urls:
-        return []
+async def _fetch_docs_for_urls(urls: list[str]) -> list[str]:
+    """Fetch each url's content, collecting non-None results in order."""
     docs = []
     for url in urls:
         content = await fetch_url_content(url)
         if content is not None:
             docs.append(content)
     return docs
+
+
+async def fetch_external_rule_docs(message: str) -> list[str]:
+    """Extract URLs from an issue message and return fetched content for each."""
+    return await _fetch_docs_for_urls(extract_urls(message))
 
 
 def is_vibe_types_doc_url(url: str) -> bool:
@@ -161,10 +163,5 @@ def is_vibe_types_doc_url(url: str) -> bool:
 
 async def fetch_vibe_types_knowledge_docs(message: str) -> list[str]:
     """Extract vibe-types knowledge-file URLs from an issue message and return fetched content for each."""
-    urls = [u for u in extract_urls(message) if is_vibe_types_doc_url(u)]
-    docs = []
-    for url in urls:
-        content = await fetch_url_content(url)
-        if content is not None:
-            docs.append(content)
-    return docs
+    urls = list(dict.fromkeys(u for u in extract_urls(message) if is_vibe_types_doc_url(u)))
+    return await _fetch_docs_for_urls(urls)

--- a/src/vibe_heal/orchestrator.py
+++ b/src/vibe_heal/orchestrator.py
@@ -7,7 +7,7 @@ from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 
 from vibe_heal.ai_tools import AIToolFactory
 from vibe_heal.ai_tools.base import AITool, AIToolType
-from vibe_heal.ai_tools.external_docs import fetch_external_rule_docs
+from vibe_heal.ai_tools.external_docs import fetch_external_rule_docs, fetch_vibe_types_knowledge_docs
 from vibe_heal.ai_tools.models import FixResult
 from vibe_heal.config import VibeHealConfig
 from vibe_heal.git import GitManager
@@ -197,7 +197,6 @@ class VibeHealOrchestrator:
         try:
             async with SonarQubeClient(self.config) as sonar_client:
                 rule = await sonar_client.get_rule_details(issue.rule)
-                return rule, None
         except SonarQubeRuleNotFoundError:
             logger.debug("Rule %s not found in SonarQube; fetching docs from issue message URLs", issue.rule)
             docs = await fetch_external_rule_docs(issue.message)
@@ -205,6 +204,13 @@ class VibeHealOrchestrator:
         except Exception as e:
             logger.warning(f"Failed to fetch rule details for {issue.rule}: {e}")
             return None, None
+
+        try:
+            knowledge_docs = await fetch_vibe_types_knowledge_docs(issue.message)
+        except Exception as e:
+            logger.warning(f"Failed to fetch vibe-types knowledge docs for issue {issue.key}: {e}")
+            knowledge_docs = None
+        return rule, knowledge_docs if knowledge_docs else None
 
     def _extract_code_context(
         self,

--- a/src/vibe_heal/orchestrator.py
+++ b/src/vibe_heal/orchestrator.py
@@ -185,6 +185,10 @@ class VibeHealOrchestrator:
     ) -> tuple[SonarQubeRule | None, list[str] | None]:
         """Fetch rule details or fallback external docs for an issue.
 
+        On success, also probes the issue message for vibe-types knowledge-file URLs and
+        includes any found docs alongside the rule. A failure fetching those knowledge docs
+        never affects the returned rule.
+
         Args:
             issue: Issue to fetch rule details for
 
@@ -205,10 +209,11 @@ class VibeHealOrchestrator:
             logger.warning(f"Failed to fetch rule details for {issue.rule}: {e}")
             return None, None
 
+        # Independent of the rule lookup above: a docs-fetch failure must never discard the already-fetched rule.
         try:
             knowledge_docs = await fetch_vibe_types_knowledge_docs(issue.message)
         except Exception as e:
-            logger.warning(f"Failed to fetch vibe-types knowledge docs for issue {issue.key}: {e}")
+            logger.warning(f"Failed to fetch vibe-types knowledge docs for issue {issue.rule}: {e}")
             knowledge_docs = None
         return rule, knowledge_docs if knowledge_docs else None
 

--- a/src/vibe_heal/orchestrator.py
+++ b/src/vibe_heal/orchestrator.py
@@ -1,5 +1,6 @@
 """Main workflow orchestration for vibe-heal."""
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -185,37 +186,40 @@ class VibeHealOrchestrator:
     ) -> tuple[SonarQubeRule | None, list[str] | None]:
         """Fetch rule details or fallback external docs for an issue.
 
-        On success, also probes the issue message for vibe-types knowledge-file URLs and
-        includes any found docs alongside the rule. A failure fetching those knowledge docs
-        never affects the returned rule.
+        Runs the vibe-types knowledge-doc lookup concurrently with the rule lookup, since the
+        two are independent. On success those docs are attached alongside the rule; a failure
+        fetching them never discards an already-fetched rule.
 
         Args:
             issue: Issue to fetch rule details for
 
         Returns:
-            Tuple of (rule, external_docs)
+            Tuple of (rule, docs)
         """
         if not self.config.include_rule_description:
             return None, None
 
-        try:
+        async def _get_rule() -> SonarQubeRule:
             async with SonarQubeClient(self.config) as sonar_client:
-                rule = await sonar_client.get_rule_details(issue.rule)
-        except SonarQubeRuleNotFoundError:
+                return await sonar_client.get_rule_details(issue.rule)
+
+        rule_outcome, knowledge_outcome = await asyncio.gather(
+            _get_rule(), fetch_vibe_types_knowledge_docs(issue.message), return_exceptions=True
+        )
+
+        if isinstance(rule_outcome, SonarQubeRuleNotFoundError):
             logger.debug("Rule %s not found in SonarQube; fetching docs from issue message URLs", issue.rule)
             docs = await fetch_external_rule_docs(issue.message)
             return None, docs if docs else None
-        except Exception as e:
-            logger.warning(f"Failed to fetch rule details for {issue.rule}: {e}")
+        if isinstance(rule_outcome, BaseException):
+            logger.warning(f"Failed to fetch rule details for {issue.rule}: {rule_outcome}")
             return None, None
 
-        # Independent of the rule lookup above: a docs-fetch failure must never discard the already-fetched rule.
-        try:
-            knowledge_docs = await fetch_vibe_types_knowledge_docs(issue.message)
-        except Exception as e:
-            logger.warning(f"Failed to fetch vibe-types knowledge docs for issue {issue.rule}: {e}")
-            knowledge_docs = None
-        return rule, knowledge_docs if knowledge_docs else None
+        if isinstance(knowledge_outcome, BaseException):
+            logger.warning(f"Failed to fetch vibe-types knowledge docs for issue {issue.rule}: {knowledge_outcome}")
+            return rule_outcome, None
+
+        return rule_outcome, knowledge_outcome if knowledge_outcome else None
 
     def _extract_code_context(
         self,

--- a/src/vibe_heal/orchestrator.py
+++ b/src/vibe_heal/orchestrator.py
@@ -209,7 +209,11 @@ class VibeHealOrchestrator:
 
         if isinstance(rule_outcome, SonarQubeRuleNotFoundError):
             logger.debug("Rule %s not found in SonarQube; fetching docs from issue message URLs", issue.rule)
-            docs = await fetch_external_rule_docs(issue.message)
+            if isinstance(knowledge_outcome, BaseException):
+                docs = await fetch_external_rule_docs(issue.message)
+            else:
+                other_docs = await fetch_external_rule_docs(issue.message, exclude_vibe_types=True)
+                docs = [*knowledge_outcome, *other_docs]
             return None, docs if docs else None
         if isinstance(rule_outcome, BaseException):
             logger.warning(f"Failed to fetch rule details for {issue.rule}: {rule_outcome}")

--- a/tests/ai_tools/test_external_docs.py
+++ b/tests/ai_tools/test_external_docs.py
@@ -224,7 +224,8 @@ class TestFetchUrlContent:
         main_url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md"
         respx.get(sha_url).mock(return_value=httpx.Response(404))
         respx.get(main_url).mock(return_value=httpx.Response(200, text="# T01 main content"))
-        content = await fetch_url_content(sha_url)
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=None):
+            content = await fetch_url_content(sha_url)
         assert content == "# T01 main content"
 
     @pytest.mark.asyncio
@@ -234,7 +235,8 @@ class TestFetchUrlContent:
         main_url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md"
         respx.get(sha_url).mock(side_effect=httpx.ConnectError("refused"))
         respx.get(main_url).mock(return_value=httpx.Response(200, text="# T01 main content"))
-        content = await fetch_url_content(sha_url)
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=None):
+            content = await fetch_url_content(sha_url)
         assert content == "# T01 main content"
 
     @pytest.mark.asyncio
@@ -244,7 +246,8 @@ class TestFetchUrlContent:
         main_url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md"
         respx.get(sha_url).mock(return_value=httpx.Response(404))
         respx.get(main_url).mock(return_value=httpx.Response(404))
-        content = await fetch_url_content(sha_url)
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", return_value=None):
+            content = await fetch_url_content(sha_url)
         assert content is None
 
     @pytest.mark.asyncio

--- a/tests/ai_tools/test_external_docs.py
+++ b/tests/ai_tools/test_external_docs.py
@@ -207,6 +207,64 @@ class TestFetchUrlContent:
         assert content is not None
         assert len(content.encode("utf-8")) <= _MAX_DOC_BYTES
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sha_pinned_url_fetches_directly_without_fallback(self) -> None:
+        sha_url = "https://raw.githubusercontent.com/jpablo/vibe-types/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/T01.md"
+        respx.get(sha_url).mock(return_value=httpx.Response(200, text="# T01 pinned content"))
+        content = await fetch_url_content(sha_url)
+        assert content == "# T01 pinned content"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sha_pinned_url_falls_back_to_main_on_404(self) -> None:
+        sha_url = "https://raw.githubusercontent.com/jpablo/vibe-types/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/T01.md"
+        main_url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md"
+        respx.get(sha_url).mock(return_value=httpx.Response(404))
+        respx.get(main_url).mock(return_value=httpx.Response(200, text="# T01 main content"))
+        content = await fetch_url_content(sha_url)
+        assert content == "# T01 main content"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sha_pinned_url_falls_back_to_main_on_network_error(self) -> None:
+        sha_url = "https://raw.githubusercontent.com/jpablo/vibe-types/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/T01.md"
+        main_url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md"
+        respx.get(sha_url).mock(side_effect=httpx.ConnectError("refused"))
+        respx.get(main_url).mock(return_value=httpx.Response(200, text="# T01 main content"))
+        content = await fetch_url_content(sha_url)
+        assert content == "# T01 main content"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sha_pinned_and_main_both_fail_returns_none(self) -> None:
+        sha_url = "https://raw.githubusercontent.com/jpablo/vibe-types/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/T01.md"
+        main_url = "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md"
+        respx.get(sha_url).mock(return_value=httpx.Response(404))
+        respx.get(main_url).mock(return_value=httpx.Response(404))
+        content = await fetch_url_content(sha_url)
+        assert content is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sha_pinned_url_falls_back_to_local_submodule_when_main_fetch_not_needed(
+        self, tmp_path: Path
+    ) -> None:
+        sha_url = "https://raw.githubusercontent.com/jpablo/vibe-types/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/T01.md"
+        respx.get(sha_url).mock(return_value=httpx.Response(404))
+        local_file = tmp_path / "T01.md"
+        local_file.write_text("# T01 local content")
+
+        def fake_local_path(url: str) -> Path | None:
+            if url == "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md":
+                return local_file
+            return None
+
+        with patch("vibe_heal.ai_tools.external_docs._vibe_types_local_path", side_effect=fake_local_path):
+            content = await fetch_url_content(sha_url)
+
+        assert content == "# T01 local content"
+
 
 class TestFetchExternalRuleDocs:
     @pytest.mark.asyncio

--- a/tests/ai_tools/test_external_docs.py
+++ b/tests/ai_tools/test_external_docs.py
@@ -354,3 +354,17 @@ class TestFetchVibeTypesKnowledgeDocs:
             "See https://raw.githubusercontent.com/jpablo/vibe-types/main/missing.md"
         )
         assert docs == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_duplicate_url_is_fetched_once(self) -> None:
+        route = respx.get("https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md").mock(
+            return_value=httpx.Response(200, text="# T01 knowledge")
+        )
+        message = (
+            "See https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md and again "
+            "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md for guidance."
+        )
+        docs = await fetch_vibe_types_knowledge_docs(message)
+        assert docs == ["# T01 knowledge"]
+        assert route.call_count == 1

--- a/tests/ai_tools/test_external_docs.py
+++ b/tests/ai_tools/test_external_docs.py
@@ -14,6 +14,8 @@ from vibe_heal.ai_tools.external_docs import (
     extract_urls,
     fetch_external_rule_docs,
     fetch_url_content,
+    fetch_vibe_types_knowledge_docs,
+    is_vibe_types_doc_url,
 )
 
 
@@ -302,3 +304,53 @@ class TestFetchExternalRuleDocs:
             docs = await fetch_external_rule_docs(f"See {url} for details.")
 
         assert docs == ["# local doc content"]
+
+
+class TestIsVibeTypesDocUrl:
+    def test_main_raw_form(self) -> None:
+        assert is_vibe_types_doc_url("https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md")
+
+    def test_refs_heads_main_raw_form(self) -> None:
+        assert is_vibe_types_doc_url("https://raw.githubusercontent.com/jpablo/vibe-types/refs/heads/main/T01.md")
+
+    def test_blob_form(self) -> None:
+        assert is_vibe_types_doc_url("https://github.com/jpablo/vibe-types/blob/main/T01.md")
+
+    def test_sha_pinned_form(self) -> None:
+        assert is_vibe_types_doc_url(
+            "https://raw.githubusercontent.com/jpablo/vibe-types/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2/T01.md"
+        )
+
+    def test_unrelated_url_is_false(self) -> None:
+        assert not is_vibe_types_doc_url("https://example.com/rule.md")
+
+
+class TestFetchVibeTypesKnowledgeDocs:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_fetches_only_vibe_types_url_from_mixed_message(self) -> None:
+        respx.get("https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md").mock(
+            return_value=httpx.Response(200, text="# T01 knowledge")
+        )
+        message = (
+            "See https://example.com/unrelated.md and "
+            "https://raw.githubusercontent.com/jpablo/vibe-types/main/T01.md for guidance."
+        )
+        docs = await fetch_vibe_types_knowledge_docs(message)
+        assert docs == ["# T01 knowledge"]
+
+    @pytest.mark.asyncio
+    async def test_no_vibe_types_url_returns_empty_list(self) -> None:
+        docs = await fetch_vibe_types_knowledge_docs("Fix this. See https://example.com/rule.md")
+        assert docs == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_skips_url_that_fails_to_fetch(self) -> None:
+        respx.get("https://raw.githubusercontent.com/jpablo/vibe-types/main/missing.md").mock(
+            return_value=httpx.Response(404)
+        )
+        docs = await fetch_vibe_types_knowledge_docs(
+            "See https://raw.githubusercontent.com/jpablo/vibe-types/main/missing.md"
+        )
+        assert docs == []

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -11,7 +11,7 @@ from vibe_heal.config import VibeHealConfig
 from vibe_heal.git import GitManager
 from vibe_heal.orchestrator import VibeHealOrchestrator
 from vibe_heal.sonarqube.exceptions import SonarQubeRuleNotFoundError
-from vibe_heal.sonarqube.models import SonarQubeIssue
+from vibe_heal.sonarqube.models import SonarQubeIssue, SonarQubeRule
 
 
 @pytest.fixture
@@ -333,3 +333,112 @@ class TestOrchestratorFixFile:
         assert summary.total_issues == 1
         assert summary.fixed == 1
         assert mock_fix_issue.call_args.kwargs.get("external_docs") == ["# External rule doc"]
+
+    @pytest.mark.asyncio
+    async def test_fix_file_rule_found_fetches_vibe_types_knowledge_docs(
+        self,
+        mock_config: VibeHealConfig,
+        mocker: MockerFixture,
+        tmp_path: Path,
+        sample_issue: SonarQubeIssue,
+    ) -> None:
+        """When get_rule_details succeeds, vibe-types knowledge docs from the issue message
+        URLs are still fetched and forwarded to fix_issue."""
+        mocker.patch("shutil.which", return_value="/usr/bin/claude")
+        mocker.patch.object(GitManager, "is_repository", return_value=True)
+
+        mock_rule = MagicMock(spec=SonarQubeRule)
+        mock_client = AsyncMock()
+        mock_client.get_issues_for_file.return_value = [sample_issue]
+        mock_client.get_rule_details.return_value = mock_rule
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mocker.patch("vibe_heal.orchestrator.SonarQubeClient", return_value=mock_client)
+
+        mocker.patch(
+            "vibe_heal.orchestrator.fetch_vibe_types_knowledge_docs",
+            return_value=["# T01 knowledge"],
+        )
+
+        mock_fix_issue = mocker.patch.object(
+            ClaudeCodeTool,
+            "fix_issue",
+            return_value=FixResult(success=True, files_modified=["test.py"]),
+        )
+
+        orchestrator = VibeHealOrchestrator(mock_config)
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        summary = await orchestrator.fix_file(str(test_file), dry_run=True)
+
+        assert summary.total_issues == 1
+        assert summary.fixed == 1
+        assert mock_fix_issue.call_args.kwargs.get("rule") is mock_rule
+        assert mock_fix_issue.call_args.kwargs.get("external_docs") == ["# T01 knowledge"]
+
+    @pytest.mark.asyncio
+    async def test_fix_file_rule_found_no_vibe_types_docs(
+        self,
+        mock_config: VibeHealConfig,
+        mocker: MockerFixture,
+        tmp_path: Path,
+        sample_issue: SonarQubeIssue,
+    ) -> None:
+        """When get_rule_details succeeds and no vibe-types URL is in the message,
+        external_docs stays None (unchanged existing behavior)."""
+        mocker.patch("shutil.which", return_value="/usr/bin/claude")
+        mocker.patch.object(GitManager, "is_repository", return_value=True)
+
+        mock_rule = MagicMock(spec=SonarQubeRule)
+        mock_client = AsyncMock()
+        mock_client.get_issues_for_file.return_value = [sample_issue]
+        mock_client.get_rule_details.return_value = mock_rule
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mocker.patch("vibe_heal.orchestrator.SonarQubeClient", return_value=mock_client)
+
+        mocker.patch("vibe_heal.orchestrator.fetch_vibe_types_knowledge_docs", return_value=[])
+
+        mock_fix_issue = mocker.patch.object(
+            ClaudeCodeTool,
+            "fix_issue",
+            return_value=FixResult(success=True, files_modified=["test.py"]),
+        )
+
+        orchestrator = VibeHealOrchestrator(mock_config)
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        await orchestrator.fix_file(str(test_file), dry_run=True)
+
+        assert mock_fix_issue.call_args.kwargs.get("external_docs") is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_rule_details_docs_fetch_error_still_returns_rule(
+        self,
+        mock_config: VibeHealConfig,
+        mocker: MockerFixture,
+        sample_issue: SonarQubeIssue,
+    ) -> None:
+        """A docs-fetch exception on the rule-found path must not discard the already-fetched
+        rule — it must not be caught by the get_rule_details try/except."""
+        mocker.patch("shutil.which", return_value="/usr/bin/claude")
+
+        mock_rule = MagicMock(spec=SonarQubeRule)
+        mock_client = AsyncMock()
+        mock_client.get_rule_details.return_value = mock_rule
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mocker.patch("vibe_heal.orchestrator.SonarQubeClient", return_value=mock_client)
+        mocker.patch(
+            "vibe_heal.orchestrator.fetch_vibe_types_knowledge_docs",
+            side_effect=RuntimeError("boom"),
+        )
+
+        orchestrator = VibeHealOrchestrator(mock_config)
+
+        rule, docs = await orchestrator._fetch_rule_details(sample_issue)
+
+        assert rule is mock_rule
+        assert docs is None

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -335,6 +335,53 @@ class TestOrchestratorFixFile:
         assert mock_fix_issue.call_args.kwargs.get("external_docs") == ["# External rule doc"]
 
     @pytest.mark.asyncio
+    async def test_fix_file_rule_not_found_reuses_vibe_types_docs(
+        self,
+        mock_config: VibeHealConfig,
+        mocker: MockerFixture,
+        tmp_path: Path,
+        sample_issue: SonarQubeIssue,
+    ) -> None:
+        """When the rule isn't found but the concurrent vibe-types knowledge-doc fetch already
+        succeeded, those docs are reused and merged with non-vibe-types docs instead of being
+        discarded and re-fetched from scratch."""
+        mocker.patch("shutil.which", return_value="/usr/bin/claude")
+        mocker.patch.object(GitManager, "is_repository", return_value=True)
+
+        mock_client = AsyncMock()
+        mock_client.get_issues_for_file.return_value = [sample_issue]
+        mock_client.get_rule_details.side_effect = SonarQubeRuleNotFoundError("rule not found")
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mocker.patch("vibe_heal.orchestrator.SonarQubeClient", return_value=mock_client)
+
+        mocker.patch(
+            "vibe_heal.orchestrator.fetch_vibe_types_knowledge_docs",
+            return_value=["# T01 knowledge"],
+        )
+        mock_fetch_external = mocker.patch(
+            "vibe_heal.orchestrator.fetch_external_rule_docs",
+            return_value=["# Other doc"],
+        )
+
+        mock_fix_issue = mocker.patch.object(
+            ClaudeCodeTool,
+            "fix_issue",
+            return_value=FixResult(success=True, files_modified=["test.py"]),
+        )
+
+        orchestrator = VibeHealOrchestrator(mock_config)
+        test_file = tmp_path / "test.py"
+        test_file.write_text("code")
+
+        summary = await orchestrator.fix_file(str(test_file), dry_run=True)
+
+        assert summary.total_issues == 1
+        assert summary.fixed == 1
+        assert mock_fix_issue.call_args.kwargs.get("external_docs") == ["# T01 knowledge", "# Other doc"]
+        mock_fetch_external.assert_called_once_with(sample_issue.message, exclude_vibe_types=True)
+
+    @pytest.mark.asyncio
     async def test_fix_file_rule_found_fetches_vibe_types_knowledge_docs(
         self,
         mock_config: VibeHealConfig,


### PR DESCRIPTION
## Summary
- When a SonarQube issue's message references a `jpablo/vibe-types` knowledge file, vibe-heal's `fix` command now fetches it and folds it into the AI fix prompt (same `external_docs` channel `create_fix_prompt()` already renders as untrusted reference content).
- Prefers the commit-SHA-pinned form of the URL, falling back to the file's current `main`-branch content if the pinned fetch fails (still checking the local `vendor/vibe-types` submodule before hitting GitHub, on the fallback leg).
- Works today, when SonarQube doesn't recognize the (ESLint-bridged) rule, and will keep working once a real SonarQube plugin registers these rules and the rule-found path is taken instead — both paths independently pick up the knowledge-file URL.

## Test plan
- [x] `uv run pytest` — 702 passed
- [x] `uv run mypy` — clean
- [x] `uv run deptry src` — clean
- [x] `uv run ruff check`/`format` — clean on all files touched by this change (one unrelated pre-existing `RUF043` finding in `tests/git/test_manager.py`, predating this branch by ~9 months, out of scope)
